### PR TITLE
Updating su26 data

### DIFF
--- a/scraping/data/summer-2026/ap-ed-es-fa-gl-hh-le-sc.json
+++ b/scraping/data/summer-2026/ap-ed-es-fa-gl-hh-le-sc.json
@@ -57,7 +57,9 @@
               "room": "VH D"
             }
           ],
-          "instructors": [],
+          "instructors": [
+            "Anirban Kar"
+          ],
           "notes": ""
         },
         {
@@ -171,7 +173,9 @@
               "room": "CLH E"
             }
           ],
-          "instructors": [],
+          "instructors": [
+            "Hyunwoo Lim"
+          ],
           "notes": ""
         }
       ]
@@ -206,7 +210,9 @@
               "room": ""
             }
           ],
-          "instructors": [],
+          "instructors": [
+            "Lee Zhixiong Li"
+          ],
           "notes": ""
         }
       ]
@@ -407,7 +413,9 @@
               "room": "VH D"
             }
           ],
-          "instructors": [],
+          "instructors": [
+            "Victoria Daniel"
+          ],
           "notes": ""
         },
         {
@@ -518,7 +526,9 @@
               "room": ""
             }
           ],
-          "instructors": [],
+          "instructors": [
+            "Len Karakowsky"
+          ],
           "notes": ""
         },
         {
@@ -563,7 +573,9 @@
               "room": "CLH A"
             }
           ],
-          "instructors": [],
+          "instructors": [
+            "Haiping Wang"
+          ],
           "notes": ""
         },
         {
@@ -597,7 +609,9 @@
               "room": ""
             }
           ],
-          "instructors": [],
+          "instructors": [
+            "Haiping Wang"
+          ],
           "notes": ""
         }
       ]
@@ -687,7 +701,9 @@
               "room": "CLH J"
             }
           ],
-          "instructors": [],
+          "instructors": [
+            "Mohsen Javdan"
+          ],
           "notes": ""
         },
         {
@@ -704,7 +720,9 @@
               "room": "CLH H"
             }
           ],
-          "instructors": [],
+          "instructors": [
+            "Mohsen Javdan"
+          ],
           "notes": ""
         },
         {
@@ -1219,7 +1237,9 @@
               "room": "DB 0007"
             }
           ],
-          "instructors": [],
+          "instructors": [
+            "Gajindra Maharaj"
+          ],
           "notes": ""
         },
         {
@@ -1670,7 +1690,9 @@
               "room": ""
             }
           ],
-          "instructors": [],
+          "instructors": [
+            "David Weitzner"
+          ],
           "notes": ""
         },
         {
@@ -1687,7 +1709,9 @@
               "room": ""
             }
           ],
-          "instructors": [],
+          "instructors": [
+            "David Weitzner"
+          ],
           "notes": ""
         }
       ]
@@ -2041,7 +2065,7 @@
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "$55.00 - Course Materials"
         }
       ]
     },
@@ -2545,8 +2569,10 @@
               "room": "HNE 030"
             }
           ],
-          "instructors": [],
-          "notes": ""
+          "instructors": [
+            "Andrew Sarta"
+          ],
+          "notes": "$6.00 - Course Materials"
         }
       ]
     },
@@ -2580,8 +2606,10 @@
               "room": "HNE 036"
             }
           ],
-          "instructors": [],
-          "notes": ""
+          "instructors": [
+            "You-Ta Chuang"
+          ],
+          "notes": "$6.00 - Course Materials"
         },
         {
           "type": "LECT",
@@ -2604,8 +2632,10 @@
               "room": "HNE 036"
             }
           ],
-          "instructors": [],
-          "notes": ""
+          "instructors": [
+            "You-Ta Chuang"
+          ],
+          "notes": "$6.00 - Course Materials"
         }
       ]
     },
@@ -2633,7 +2663,7 @@
             }
           ],
           "instructors": [],
-          "notes": "(Backup)"
+          "notes": "$6.00 - Course Materials | (Backup)"
         },
         {
           "type": "LECT",
@@ -2650,7 +2680,7 @@
             }
           ],
           "instructors": [],
-          "notes": "(Backup)"
+          "notes": "$6.00 - Course Materials | (Backup)"
         },
         {
           "type": "LECT",
@@ -2667,7 +2697,7 @@
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "$6.00 - Course Materials"
         }
       ]
     },
@@ -2694,7 +2724,9 @@
               "room": ""
             }
           ],
-          "instructors": [],
+          "instructors": [
+            "Joel Marcus"
+          ],
           "notes": ""
         }
       ]
@@ -2738,7 +2770,9 @@
               "room": ""
             }
           ],
-          "instructors": [],
+          "instructors": [
+            "Karl Schmid"
+          ],
           "notes": ""
         },
         {
@@ -2862,7 +2896,9 @@
               "room": ""
             }
           ],
-          "instructors": [],
+          "instructors": [
+            "Arun Chaudhuri"
+          ],
           "notes": ""
         },
         {
@@ -3030,7 +3066,9 @@
               "room": ""
             }
           ],
-          "instructors": [],
+          "instructors": [
+            "Jillian Fulton"
+          ],
           "notes": ""
         },
         {
@@ -3193,7 +3231,7 @@
           "instructors": [
             "Carmela Shehadi Mishaiel"
           ],
-          "notes": "In order to enrol, please complete the online Arabic questionnaire ."
+          "notes": "In order to enrol, please complete the online Arabic placement test ."
         }
       ]
     },
@@ -3230,7 +3268,7 @@
           "instructors": [
             "Carmela Shehadi Mishaiel"
           ],
-          "notes": "In order to enrol, please complete the online Arabic questionnaire"
+          "notes": "In order to enrol, please complete the online Arabic placement test ."
         }
       ]
     },
@@ -3397,7 +3435,7 @@
             }
           ],
           "instructors": [],
-          "notes": "Reserved for students in the Deaf and Hard of Hearing Teacher Education Program."
+          "notes": "Reserved for students in the Deaf and Hard of Hearing Teacher Education Program. | $135.00 - Course Materials"
         }
       ]
     },
@@ -4897,9 +4935,7 @@
               "room": ""
             }
           ],
-          "instructors": [
-            "Alexander Mills"
-          ],
+          "instructors": [],
           "notes": ""
         }
       ]
@@ -5911,7 +5947,7 @@
               "time": "13:00",
               "duration": "170",
               "campus": "Glendon",
-              "room": ""
+              "room": "YH A201"
             }
           ],
           "instructors": [],
@@ -6226,14 +6262,14 @@
               "time": "11:30",
               "duration": "170",
               "campus": "Keele",
-              "room": "R S128"
+              "room": ""
             },
             {
               "day": "R",
               "time": "11:30",
               "duration": "170",
               "campus": "Keele",
-              "room": "R S128"
+              "room": ""
             }
           ],
           "instructors": [
@@ -6376,7 +6412,7 @@
           "instructors": [
             "Kyle Belozerov"
           ],
-          "notes": ""
+          "notes": "$12.00 - Course Materials"
         },
         {
           "type": "TUTR",
@@ -6404,7 +6440,7 @@
               "time": "10:30",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "LSB 207"
             }
           ],
           "instructors": [],
@@ -6420,7 +6456,7 @@
               "time": "10:30",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "LSB 211"
             }
           ],
           "instructors": [],
@@ -6436,7 +6472,7 @@
               "time": "14:30",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "LSB 207"
             }
           ],
           "instructors": [],
@@ -6452,7 +6488,7 @@
               "time": "14:30",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "LSB 211"
             }
           ],
           "instructors": [],
@@ -6468,7 +6504,7 @@
               "time": "14:30",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "LSB 207"
             }
           ],
           "instructors": [],
@@ -6484,7 +6520,7 @@
               "time": "14:30",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "LSB 211"
             }
           ],
           "instructors": [],
@@ -6500,7 +6536,7 @@
               "time": "10:30",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "LSB 207"
             }
           ],
           "instructors": [],
@@ -6516,7 +6552,7 @@
               "time": "10:30",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "LSB 211"
             }
           ],
           "instructors": [],
@@ -6532,7 +6568,7 @@
               "time": "14:30",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "LSB 207"
             }
           ],
           "instructors": [],
@@ -6548,7 +6584,7 @@
               "time": "14:30",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "LSB 211"
             }
           ],
           "instructors": [],
@@ -6564,7 +6600,7 @@
               "time": "14:30",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "LSB 207"
             }
           ],
           "instructors": [],
@@ -6580,7 +6616,7 @@
               "time": "14:30",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "LSB 211"
             }
           ],
           "instructors": [],
@@ -6596,7 +6632,7 @@
               "time": "13:30",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "LSB 207"
             }
           ],
           "instructors": [],
@@ -6612,7 +6648,7 @@
               "time": "13:30",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "LSB 211"
             }
           ],
           "instructors": [],
@@ -6653,7 +6689,7 @@
           "instructors": [
             "Kyle Belozerov"
           ],
-          "notes": ""
+          "notes": "$12.00 - Course Materials"
         },
         {
           "type": "TUTR",
@@ -6777,7 +6813,7 @@
               "time": "10:30",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "LSB 201"
             }
           ],
           "instructors": [],
@@ -6793,7 +6829,7 @@
               "time": "10:30",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "LSB 227"
             }
           ],
           "instructors": [],
@@ -6809,7 +6845,7 @@
               "time": "14:30",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "LSB 201"
             }
           ],
           "instructors": [],
@@ -6825,7 +6861,7 @@
               "time": "14:30",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "LSB 227"
             }
           ],
           "instructors": [],
@@ -6930,7 +6966,7 @@
           "instructors": [
             "Raji Iyer"
           ],
-          "notes": ""
+          "notes": "$10.00 - Course Materials"
         },
         {
           "type": "TUTR",
@@ -7134,7 +7170,7 @@
           "instructors": [
             "Raji Iyer"
           ],
-          "notes": ""
+          "notes": "$11.00 - Course Materials"
         },
         {
           "type": "TUTR",
@@ -7162,7 +7198,7 @@
               "time": "14:30",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "CB 335"
             }
           ],
           "instructors": [],
@@ -7194,7 +7230,7 @@
               "time": "14:30",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "CB 315"
             }
           ],
           "instructors": [],
@@ -7258,7 +7294,7 @@
               "time": "14:30",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "CB 315"
             }
           ],
           "instructors": [],
@@ -7290,7 +7326,7 @@
               "time": "14:30",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "CB 335"
             }
           ],
           "instructors": [],
@@ -7322,7 +7358,7 @@
               "time": "14:30",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "CB 315"
             }
           ],
           "instructors": [],
@@ -7354,7 +7390,7 @@
               "time": "14:30",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "CB 335"
             }
           ],
           "instructors": [],
@@ -7414,25 +7450,25 @@
               "time": "11:30",
               "duration": "140",
               "campus": "Keele",
-              "room": "LAS A"
+              "room": "VH A"
             },
             {
               "day": "T",
               "time": "11:30",
               "duration": "140",
               "campus": "Keele",
-              "room": "LAS A"
+              "room": "VH A"
             },
             {
               "day": "W",
               "time": "11:30",
               "duration": "50",
               "campus": "Keele",
-              "room": "LAS A"
+              "room": "VH A"
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "$11.00 - Course Materials"
         },
         {
           "type": "TUTR",
@@ -7444,7 +7480,7 @@
               "time": "12:30",
               "duration": "80",
               "campus": "Keele",
-              "room": "LAS A"
+              "room": "VH A"
             }
           ],
           "instructors": [],
@@ -7460,7 +7496,7 @@
               "time": "14:30",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "CB 335"
             }
           ],
           "instructors": [],
@@ -7492,7 +7528,7 @@
               "time": "14:30",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "CB 315"
             }
           ],
           "instructors": [],
@@ -7508,7 +7544,7 @@
               "time": "14:30",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "CB 335"
             }
           ],
           "instructors": [],
@@ -7540,7 +7576,7 @@
               "time": "14:30",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "CB 315"
             }
           ],
           "instructors": [],
@@ -7556,7 +7592,7 @@
               "time": "14:30",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "CB 335"
             }
           ],
           "instructors": [],
@@ -7588,7 +7624,7 @@
               "time": "14:30",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "CB 315"
             }
           ],
           "instructors": [],
@@ -9282,7 +9318,7 @@
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "$500.00 - Course Materials"
         }
       ]
     },
@@ -9338,7 +9374,7 @@
             }
           ],
           "instructors": [],
-          "notes": "This course is available exclusively to students in EUC; enrolment is subject to the Career Centre approval. Contact askcoop@yorku.ca ."
+          "notes": "This course is available exclusively to students in EUC; enrolment is subject to the Career Centre approval. Contact askcoop@yorku.ca . | $500.00 - Course Materials"
         }
       ]
     },
@@ -9366,7 +9402,7 @@
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "$500.00 - Course Materials"
         }
       ]
     },
@@ -9394,7 +9430,7 @@
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "$500.00 - Course Materials"
         }
       ]
     },
@@ -9422,7 +9458,7 @@
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "$500.00 - Course Materials"
         }
       ]
     },
@@ -9450,7 +9486,7 @@
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "$500.00 - Course Materials"
         }
       ]
     },
@@ -9478,7 +9514,7 @@
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "$500.00 - Course Materials"
         }
       ]
     },
@@ -9536,7 +9572,7 @@
           "instructors": [
             "Brandon Takayuki Hillier"
           ],
-          "notes": "This course is available exclusively to students in EUC; enrolment is subject to the Career Centre approval. Contact askcoop@yorku.ca ."
+          "notes": "This course is available exclusively to students in EUC; enrolment is subject to the Career Centre approval. Contact askcoop@yorku.ca . | $500.00 - Course Materials"
         }
       ]
     },
@@ -9564,7 +9600,7 @@
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "$500.00 - Course Materials"
         }
       ]
     },
@@ -10102,7 +10138,7 @@
     {
       "faculty": "FA",
       "department": "DANC",
-      "term": "SU",
+      "term": "S1",
       "courseTitle": "Dance and Popular Culture",
       "courseId": "3540",
       "credits": "3.00",
@@ -10112,7 +10148,7 @@
           "type": "STDO",
           "meetNumber": "01",
           "section": "A",
-          "catalogNumber": "D28N01",
+          "catalogNumber": "Y76D01",
           "schedule": [
             {
               "day": "M",
@@ -10129,6 +10165,26 @@
               "room": "ACW 009"
             }
           ],
+          "instructors": [],
+          "notes": ""
+        }
+      ]
+    },
+    {
+      "faculty": "FA",
+      "department": "DANC",
+      "term": "SU",
+      "courseTitle": "Dance and Popular Culture",
+      "courseId": "3540",
+      "credits": "3.00",
+      "languageOfInstruction": "EN",
+      "sections": [
+        {
+          "type": "STDO",
+          "meetNumber": "01",
+          "section": "A",
+          "catalogNumber": "Cancelled",
+          "schedule": [],
           "instructors": [],
           "notes": ""
         }
@@ -11865,9 +11921,7 @@
               "room": "DB 0014"
             }
           ],
-          "instructors": [
-            "Jeleta Kebede"
-          ],
+          "instructors": [],
           "notes": ""
         },
         {
@@ -12438,7 +12492,7 @@
           "instructors": [
             "John Hupfield"
           ],
-          "notes": "Reserved for the Waaban cohort."
+          "notes": "Reserved for the Waaban cohort. Course scheduled to take place on Keele campus."
         }
       ]
     },
@@ -12468,7 +12522,7 @@
           "instructors": [
             "John Hupfield"
           ],
-          "notes": "Reserved for the Waaban cohort."
+          "notes": "Reserved for the Waaban cohort. Course scheduled to take place on Keele campus."
         }
       ]
     },
@@ -12593,7 +12647,7 @@
           "instructors": [
             "Rebecca Beaulne-Stuebing"
           ],
-          "notes": "Reserved for the Waaban cohort."
+          "notes": "Reserved for the Waaban cohort. Course scheduled to take place on Keele campus."
         }
       ]
     },
@@ -12672,7 +12726,7 @@
     {
       "faculty": "ED",
       "department": "EDJI",
-      "term": "C3",
+      "term": "C1",
       "courseTitle": "Language & Literacy in the Junior-Intermediate Divisions",
       "courseId": "1000",
       "credits": "3.00",
@@ -12682,8 +12736,15 @@
           "type": "LECT",
           "meetNumber": "01",
           "section": "T",
-          "catalogNumber": "C61A01",
+          "catalogNumber": "M49Q01",
           "schedule": [
+            {
+              "day": "W",
+              "time": "9:00",
+              "duration": "170",
+              "campus": "Keele",
+              "room": ""
+            },
             {
               "day": "R",
               "time": "9:00",
@@ -12695,7 +12756,64 @@
           "instructors": [
             "Zuhra Abawi"
           ],
+          "notes": "Reserved for the Waaban cohort. Course scheduled to take place on Keele campus."
+        }
+      ]
+    },
+    {
+      "faculty": "ED",
+      "department": "EDJI",
+      "term": "C3",
+      "courseTitle": "Language & Literacy in the Junior-Intermediate Divisions",
+      "courseId": "1000",
+      "credits": "3.00",
+      "languageOfInstruction": "EN",
+      "sections": [
+        {
+          "type": "LECT",
+          "meetNumber": "01",
+          "section": "T",
+          "catalogNumber": "Cancelled",
+          "schedule": [],
+          "instructors": [],
           "notes": "Reserved for the Waaban cohort."
+        }
+      ]
+    },
+    {
+      "faculty": "ED",
+      "department": "EDPJ",
+      "term": "C1",
+      "courseTitle": "Language & Literacy in the Primary-Junior Divisions",
+      "courseId": "1000",
+      "credits": "3.00",
+      "languageOfInstruction": "EN",
+      "sections": [
+        {
+          "type": "LECT",
+          "meetNumber": "01",
+          "section": "T",
+          "catalogNumber": "U40U01",
+          "schedule": [
+            {
+              "day": "W",
+              "time": "9:00",
+              "duration": "170",
+              "campus": "Keele",
+              "room": ""
+            },
+            {
+              "day": "R",
+              "time": "9:00",
+              "duration": "170",
+              "campus": "Keele",
+              "room": ""
+            }
+          ],
+          "instructors": [
+            "Zuhra Abawi"
+          ],
+          "notes": "Reserved for the Waaban cohort. Course scheduled to take place on Keele campus."
         }
       ]
     },
@@ -12729,19 +12847,9 @@
           "type": "LECT",
           "meetNumber": "01",
           "section": "T",
-          "catalogNumber": "V62M01",
-          "schedule": [
-            {
-              "day": "R",
-              "time": "9:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Zuhra Abawi"
-          ],
+          "catalogNumber": "Cancelled",
+          "schedule": [],
+          "instructors": [],
           "notes": "Reserved for the Waaban cohort."
         }
       ]
@@ -12798,7 +12906,7 @@
             }
           ],
           "instructors": [],
-          "notes": "Reserved for the Waaban cohort."
+          "notes": "Reserved for the Waaban cohort. Course scheduled to take place on Keele campus."
         }
       ]
     },
@@ -12826,7 +12934,7 @@
             }
           ],
           "instructors": [],
-          "notes": "Reserved for the TMU BEd cohort. Course will be offered at Toronto Metropolitan University (TMU). Students must have presented a cleared, current Vulnerable Sector Screening from their local police department prior to entering placements.Â"
+          "notes": "Reserved for the TMU BEd cohort. Course will be offered at Toronto Metropolitan University (TMU). Students must have presented a cleared, current Vulnerable Sector Screening from their local police department prior to entering placements.Â | $350.00 - Course Materials"
         }
       ]
     },
@@ -12893,7 +13001,7 @@
           "instructors": [
             "Steven John Alsop"
           ],
-          "notes": "This course will be offered at Las Nubes. Permission Only."
+          "notes": "This course will be offered at Las Nubes. By permission only."
         }
       ]
     },
@@ -12958,7 +13066,7 @@
           "instructors": [
             "Rebecca Beaulne-Stuebing"
           ],
-          "notes": "Reserved for the Waaban cohort."
+          "notes": "Reserved for the Waaban cohort. Course scheduled to take place on Keele campus."
         }
       ]
     },
@@ -13099,23 +13207,8 @@
           "type": "LECT",
           "meetNumber": "01",
           "section": "B",
-          "catalogNumber": "X56H01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
+          "catalogNumber": "Cancelled",
+          "schedule": [],
           "instructors": [],
           "notes": ""
         }
@@ -13182,7 +13275,42 @@
           "instructors": [
             "Steven John Alsop"
           ],
-          "notes": "This course will be offered at Las Nubes. Permission Only."
+          "notes": "This course will be offered at Las Nubes. By permission only."
+        }
+      ]
+    },
+    {
+      "faculty": "ED",
+      "department": "EDUC",
+      "term": "C1",
+      "courseTitle": "Education and Human Rights",
+      "courseId": "3730",
+      "credits": "3.00",
+      "languageOfInstruction": "EN",
+      "sections": [
+        {
+          "type": "LECT",
+          "meetNumber": "01",
+          "section": "A",
+          "catalogNumber": "Y89P01",
+          "schedule": [
+            {
+              "day": "T",
+              "time": "14:30",
+              "duration": "170",
+              "campus": "Keele",
+              "room": ""
+            },
+            {
+              "day": "R",
+              "time": "14:30",
+              "duration": "170",
+              "campus": "Keele",
+              "room": ""
+            }
+          ],
+          "instructors": [],
+          "notes": ""
         }
       ]
     },
@@ -13920,7 +14048,7 @@
           "instructors": [
             "Hui Wang"
           ],
-          "notes": ""
+          "notes": "$5.00 - Course Materials"
         },
         {
           "type": "TUTR",
@@ -13971,7 +14099,7 @@
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "$5.00 - Course Materials"
         },
         {
           "type": "LAB",
@@ -14056,7 +14184,7 @@
           "instructors": [
             "Jackie Wang"
           ],
-          "notes": ""
+          "notes": "$5.00 - Course Materials"
         },
         {
           "type": "LAB",
@@ -14134,7 +14262,7 @@
           "instructors": [
             "Sukhwant Kaur Sagar"
           ],
-          "notes": ""
+          "notes": "$5.00 - Course Materials"
         },
         {
           "type": "LAB",
@@ -14309,7 +14437,7 @@
           "instructors": [
             "Houshang Karimi"
           ],
-          "notes": ""
+          "notes": "$5.00 - Course Materials"
         },
         {
           "type": "LAB",
@@ -14410,7 +14538,7 @@
           "instructors": [
             "Jackie Wang"
           ],
-          "notes": ""
+          "notes": "$5.00 - Course Materials"
         },
         {
           "type": "TUTR",
@@ -14454,7 +14582,7 @@
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "$5.00 - Course Materials"
         }
       ]
     },
@@ -14489,7 +14617,7 @@
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "$5.00 - Course Materials"
         }
       ]
     },
@@ -14519,7 +14647,7 @@
           "instructors": [
             "Gias Uddin"
           ],
-          "notes": ""
+          "notes": "$5.00 - Course Materials"
         },
         {
           "type": "LAB",
@@ -14623,7 +14751,7 @@
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "$5.00 - Course Materials"
         }
       ]
     },
@@ -14658,7 +14786,7 @@
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "$5.00 - Course Materials"
         }
       ]
     },
@@ -14695,7 +14823,7 @@
           "instructors": [
             "Natalija Vlajic"
           ],
-          "notes": ""
+          "notes": "$5.00 - Course Materials"
         },
         {
           "type": "LAB",
@@ -14811,7 +14939,7 @@
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "Section B is part of the Cross-Campus Capstone Classroom (C4) Launchpad program. From June 1 to June 12 (with Capstone Day on June 19), students will work in interdisciplinary teams on a project sprint focused on real-world social impact. To apply, visit https://www.yorku.ca/c4/apply-for-c4/ . | $5.00 - Course Materials"
         }
       ]
     },
@@ -14839,7 +14967,7 @@
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "$5.00 - Course Materials"
         }
       ]
     },
@@ -14936,7 +15064,7 @@
           "instructors": [
             "Alvine Boaye Belle"
           ],
-          "notes": ""
+          "notes": "$5.00 - Course Materials"
         },
         {
           "type": "LAB",
@@ -15102,7 +15230,7 @@
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "$5.00 - Course Materials"
         }
       ]
     },
@@ -15130,7 +15258,7 @@
             }
           ],
           "instructors": [],
-          "notes": "This is an online and asynchronous course. There are no specified meeting times. Additional information will be provided by your course instructor."
+          "notes": "This course is currently reserved for English, Creative Writing, and English & Professional Writing students. Remaining seats will open to all non-majors/minors on April 9, 2026. This is an online, asynchronous course. There are no scheduled meeting times. Additional information will be provided by your course instructor."
         },
         {
           "type": "ONLN",
@@ -15206,7 +15334,7 @@
             }
           ],
           "instructors": [],
-          "notes": "This is an online and asynchronous course. There are no specified meeting times. Additional information will be provided by your course instructor."
+          "notes": "This course is currently reserved for English, Creative Writing, and English & Professional Writing students. Remaining seats will open to all non-majors/minors on April 9, 2026. This is an online, asynchronous course. There are no scheduled meeting times. Additional information will be provided by your course instructor."
         },
         {
           "type": "ONLN",
@@ -15640,7 +15768,7 @@
           "instructors": [
             "Terry Goldie"
           ],
-          "notes": "This is an online and asynchronous course. There are no specified meeting times. Additional information will be provided by your course instructor."
+          "notes": "This course is currently reserved for 2nd- and 3rd-year English, Creative Writing, and English & Professional Writing students. Remaining seats will open to 4th-year EN/CRWR/ENPR students and all non-majors/minors on April 8, 2026. This is an online, asynchronous course. There are no scheduled meeting times. Additional information will be provided by your course instructor."
         }
       ]
     },
@@ -15677,7 +15805,7 @@
           "instructors": [
             "Deanne Williams"
           ],
-          "notes": "This course will be held in person at the assigned location. This is an experiential learning course, and students are expected to attend a live performance at the Shaw Festival Theatre on July 14, 2026."
+          "notes": "This course is currently reserved for 2nd- and 3rd-year English, Creative Writing, and English & Professional Writing students. Remaining seats will open to 4th-year EN/CRWR/ENPR students and all non-majors/minors on April 8, 2026. This course will be held in person at the assigned location. This is an experiential learning course, and students are expected to attend a live performance at the Shaw Festival Theatre on July 14, 2026. | $228.00 - Course Materials"
         }
       ]
     },
@@ -15697,7 +15825,7 @@
           "catalogNumber": "Cancelled",
           "schedule": [],
           "instructors": [],
-          "notes": "This course will be held in person at the assigned location."
+          "notes": "This course is currently reserved for 2nd- and 3rd-year English, Creative Writing, and English & Professional Writing students. Remaining seats will open to 4th-year EN/CRWR/ENPR students and all non-majors/minors on April 8, 2026. This course will be held in person at the assigned location."
         },
         {
           "type": "LECT",
@@ -15841,7 +15969,7 @@
             }
           ],
           "instructors": [],
-          "notes": "This course will be held in person at the assigned location."
+          "notes": "This course is currently reserved for 3rd- and 4th-year English, Creative Writing, and English & Professional Writing students. Remaining seats will open to all non-majors/minors in 3rd- or 4th-year on March 31, 2026. This course will be held in person at the assigned location."
         },
         {
           "type": "TUTR",
@@ -15956,7 +16084,7 @@
             }
           ],
           "instructors": [],
-          "notes": "This course will be held in person at the assigned location. This is an experiential learning course, and students are expected to attend live performances at the Stratford Festival on May 22, June 12, and July 8, 2026."
+          "notes": "This course is currently reserved for 3rd- and 4th-year English, Creative Writing, and English & Professional Writing students. Remaining seats will open to all non-majors/minors in 3rd- or 4th-year on March 31, 2026. This course will be held in person at the assigned location. This is an experiential learning course, and students are expected to attend live performances at the Stratford Festival on May 22, June 12, and July 8, 2026. | $228.00 - Course Materials"
         }
       ]
     },
@@ -16019,7 +16147,7 @@
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "This course requires an application and thesis proposal, due May 4, 2026. Registration is not confirmed until your proposal is approved by the Undergraduate Program Director. Students should contact a potential supervisor before or during the Winter 2026 term to discuss their research interests and begin preparing their proposal. For more information, contact the Department of English at lapsengl@yorku.ca."
         }
       ]
     },
@@ -16056,7 +16184,7 @@
           "instructors": [
             "Marcia S. Blumberg"
           ],
-          "notes": "This course will be delivered remotely with synchronous class sessions: the meetings are scheduled on the Day(s) and Start Time(s) listed here."
+          "notes": "This course is currently reserved for 4th-year English, Creative Writing, and English & Professional Writing (Honours) students. Remaining seats will open to all non-majors/minors in 4th-year Honours programs on March 31, 2026. This course will be delivered remotely with synchronous class sessions: the meetings are scheduled on the Day(s) and Start Time(s) listed here."
         }
       ]
     },
@@ -16111,7 +16239,7 @@
             }
           ],
           "instructors": [],
-          "notes": "This course will be held in person at the assigned location."
+          "notes": "This course is currently reserved for 4th-year English, Creative Writing, and English & Professional Writing (Honours) students. Remaining seats will open to all non-majors/minors in 4th-year Honours programs on March 31, 2026. This course will be held in person at the assigned location."
         }
       ]
     },
@@ -16146,7 +16274,7 @@
             }
           ],
           "instructors": [],
-          "notes": "This course will be held in person at the assigned location."
+          "notes": "This course is currently reserved for 4th-year English, Creative Writing, and English & Professional Writing (Honours) students. Remaining seats will open to all non-majors/minors in 4th-year Honours programs on March 31, 2026. This course will be held in person at the assigned location."
         }
       ]
     },
@@ -16181,7 +16309,7 @@
             }
           ],
           "instructors": [],
-          "notes": "This course will be held in person at the assigned location."
+          "notes": "This course is currently reserved for 4th-year English, Creative Writing, and English & Professional Writing (Honours) students. Remaining seats will open to all non-majors/minors in 4th-year Honours programs on March 31, 2026. This course will be held in person at the assigned location."
         }
       ]
     },
@@ -16243,7 +16371,9 @@
               "room": "VH C"
             }
           ],
-          "instructors": [],
+          "instructors": [
+            "Benard Isojeh"
+          ],
           "notes": ""
         },
         {
@@ -16292,7 +16422,7 @@
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "(Backup)"
         },
         {
           "type": "TUTR",
@@ -16308,7 +16438,7 @@
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "(Backup)"
         },
         {
           "type": "TUTR",
@@ -16340,7 +16470,7 @@
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "(Backup)"
         }
       ]
     },
@@ -16455,7 +16585,7 @@
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "(Backup)"
         },
         {
           "type": "TUTR",
@@ -16471,7 +16601,7 @@
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "(Backup)"
         }
       ]
     },
@@ -16527,7 +16657,7 @@
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "Section Z is part of the Cross-Campus Capstone Classroom (C4) Launchpad program. From June 1 to June 12 (with Capstone Day on June 19), students will work in interdisciplinary teams on a project sprint focused on real-world social impact. To apply, visit https://www.yorku.ca/c4/apply-for-c4/ ."
         }
       ]
     },
@@ -16744,7 +16874,7 @@
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "This offering is part of the Cross-Campus Capstone Classroom (C4) Launchpad program. From June 1 to June 12 (with Capstone Day on June 19), students will work in interdisciplinary teams on a project sprint focused on real-world social impact. To apply, visit https://www.yorku.ca/c4/apply-for-c4/ ."
         }
       ]
     },
@@ -17057,9 +17187,7 @@
               "room": ""
             }
           ],
-          "instructors": [
-            "Alexander Mills"
-          ],
+          "instructors": [],
           "notes": ""
         }
       ]
@@ -18059,7 +18187,7 @@
             }
           ],
           "instructors": [],
-          "notes": "This course includes extensive off-campus field trips, with additional course fees required."
+          "notes": "This course includes extensive off-campus field trips, with additional course fees required. | $30.00 - Course Materials"
         }
       ]
     },
@@ -18865,23 +18993,8 @@
           "type": "ONLN",
           "meetNumber": "01",
           "section": "M",
-          "catalogNumber": "G88J01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "12:30",
-              "duration": "230",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "12:30",
-              "duration": "230",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
+          "catalogNumber": "Cancelled",
+          "schedule": [],
           "instructors": [
             "Lukas Arnason"
           ],
@@ -20231,7 +20344,9 @@
               "room": ""
             }
           ],
-          "instructors": [],
+          "instructors": [
+            "Jeffery Roger Webber"
+          ],
           "notes": ""
         },
         {
@@ -20377,8 +20492,10 @@
               "room": ""
             }
           ],
-          "instructors": [],
-          "notes": "This course will be delievered fully online in an Asynchronous format. Additional information will be provided by your course instructor."
+          "instructors": [
+            "Stephen R Gill"
+          ],
+          "notes": "This course will be delivered fully online in an Asynchronous format. Additional information will be provided by your course instructor."
         }
       ]
     },
@@ -20405,8 +20522,10 @@
               "room": ""
             }
           ],
-          "instructors": [],
-          "notes": "This course will be delievered fully online in an Asynchronous format. Additional information will be provided by your course instructor."
+          "instructors": [
+            "Stephen R Gill"
+          ],
+          "notes": "This course will be delivered fully online in an Asynchronous format. Additional information will be provided by your course instructor."
         }
       ]
     },
@@ -20433,8 +20552,10 @@
               "room": ""
             }
           ],
-          "instructors": [],
-          "notes": ""
+          "instructors": [
+            "Isabella C. Bakker"
+          ],
+          "notes": "This course will be delivered fully online in an Asynchronous format. Additional information will be provided by your course instructor."
         }
       ]
     },
@@ -20461,8 +20582,10 @@
               "room": ""
             }
           ],
-          "instructors": [],
-          "notes": "This course will be delievered fully online in an Asynchronous format. Additional information will be provided by your course instructor."
+          "instructors": [
+            "Isabella C. Bakker"
+          ],
+          "notes": "This course will be delivered fully online in an Asynchronous format. Additional information will be provided by your course instructor."
         }
       ]
     },
@@ -21586,6 +21709,43 @@
     {
       "faculty": "AP",
       "department": "HIST",
+      "term": "S1",
+      "courseTitle": "Jews and Muslims",
+      "courseId": "3919",
+      "credits": "3.00",
+      "languageOfInstruction": "EN",
+      "sections": [
+        {
+          "type": "SEMR",
+          "meetNumber": "01",
+          "section": "A",
+          "catalogNumber": "J95M01 (AP HUMA) D42V01 (AP JWST) T89G01 (AP HIST) N36P01 (AP RLST)",
+          "schedule": [
+            {
+              "day": "T",
+              "time": "11:30",
+              "duration": "170",
+              "campus": "Keele",
+              "room": "DB 0015"
+            },
+            {
+              "day": "R",
+              "time": "11:30",
+              "duration": "170",
+              "campus": "Keele",
+              "room": "DB 0015"
+            }
+          ],
+          "instructors": [
+            "Marc Herman"
+          ],
+          "notes": ""
+        }
+      ]
+    },
+    {
+      "faculty": "AP",
+      "department": "HIST",
       "term": "SU",
       "courseTitle": "Supervised Reading and Research",
       "courseId": "3990",
@@ -21728,14 +21888,14 @@
               "time": "14:30",
               "duration": "170",
               "campus": "Keele",
-              "room": "R S128"
+              "room": ""
             },
             {
               "day": "R",
               "time": "14:30",
               "duration": "170",
               "campus": "Keele",
-              "room": "R S128"
+              "room": ""
             }
           ],
           "instructors": [
@@ -22755,7 +22915,27 @@
           "type": "ONLN",
           "meetNumber": "01",
           "section": "A",
-          "catalogNumber": "C67T01",
+          "catalogNumber": "Cancelled",
+          "schedule": [],
+          "instructors": [],
+          "notes": ""
+        }
+      ]
+    },
+    {
+      "faculty": "AP",
+      "department": "HRM",
+      "term": "S1",
+      "courseTitle": "Employment Law",
+      "courseId": "3420",
+      "credits": "3.00",
+      "languageOfInstruction": "EN",
+      "sections": [
+        {
+          "type": "ONLN",
+          "meetNumber": "01",
+          "section": "A",
+          "catalogNumber": "C40Q01",
           "schedule": [
             {
               "day": "",
@@ -22783,11 +22963,31 @@
           "type": "ONLN",
           "meetNumber": "01",
           "section": "M",
-          "catalogNumber": "W26P01",
+          "catalogNumber": "Cancelled",
+          "schedule": [],
+          "instructors": [],
+          "notes": ""
+        }
+      ]
+    },
+    {
+      "faculty": "AP",
+      "department": "HRM",
+      "term": "SU",
+      "courseTitle": "Industrial Relations",
+      "courseId": "3422",
+      "credits": "3.00",
+      "languageOfInstruction": "EN",
+      "sections": [
+        {
+          "type": "ONLN",
+          "meetNumber": "01",
+          "section": "A",
+          "catalogNumber": "J86C01",
           "schedule": [
             {
               "day": "",
-              "time": "0:00",
+              "time": "",
               "duration": "0",
               "campus": "Keele",
               "room": ""
@@ -23154,7 +23354,7 @@
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "$55.00 - Course Materials"
         }
       ]
     },
@@ -24459,14 +24659,14 @@
           "catalogNumber": "N48M03 (AP HUMA) Z93S03 (AP RLST)",
           "schedule": [
             {
-              "day": "M",
+              "day": "T",
               "time": "13:30",
               "duration": "110",
               "campus": "Keele",
               "room": ""
             },
             {
-              "day": "W",
+              "day": "R",
               "time": "13:30",
               "duration": "110",
               "campus": "Keele",
@@ -24505,14 +24705,14 @@
           "catalogNumber": "N48M05 (AP HUMA) Z93S05 (AP RLST)",
           "schedule": [
             {
-              "day": "M",
+              "day": "T",
               "time": "15:30",
               "duration": "110",
               "campus": "Keele",
               "room": ""
             },
             {
-              "day": "W",
+              "day": "R",
               "time": "15:30",
               "duration": "110",
               "campus": "Keele",
@@ -24551,14 +24751,14 @@
           "catalogNumber": "N48M07 (AP HUMA) Z93S07 (AP RLST)",
           "schedule": [
             {
-              "day": "M",
+              "day": "T",
               "time": "17:30",
               "duration": "110",
               "campus": "Keele",
               "room": ""
             },
             {
-              "day": "W",
+              "day": "R",
               "time": "17:30",
               "duration": "110",
               "campus": "Keele",
@@ -24925,7 +25125,7 @@
             }
           ],
           "instructors": [],
-          "notes": "This course will be held in person at the assigned location."
+          "notes": "This course is currently reserved for 3rd- and 4th-year English, Creative Writing, and English & Professional Writing students. Remaining seats will open to all non-majors/minors in 3rd- or 4th-year on March 31, 2026. This course will be held in person at the assigned location."
         },
         {
           "type": "TUTR",
@@ -25249,7 +25449,27 @@
           "type": "SEMR",
           "meetNumber": "01",
           "section": "A",
-          "catalogNumber": "D25D01 (AP HUMA) Z64D01 (AP JWST) X11M01 (AP RLST)",
+          "catalogNumber": "Cancelled",
+          "schedule": [],
+          "instructors": [],
+          "notes": ""
+        }
+      ]
+    },
+    {
+      "faculty": "AP",
+      "department": "HUMA",
+      "term": "S1",
+      "courseTitle": "Jews and Muslims",
+      "courseId": "3919",
+      "credits": "3.00",
+      "languageOfInstruction": "EN",
+      "sections": [
+        {
+          "type": "SEMR",
+          "meetNumber": "01",
+          "section": "A",
+          "catalogNumber": "J95M01 (AP HUMA) D42V01 (AP JWST) T89G01 (AP HIST) N36P01 (AP RLST)",
           "schedule": [
             {
               "day": "T",
@@ -25675,14 +25895,14 @@
               "time": "11:30",
               "duration": "170",
               "campus": "Keele",
-              "room": "R S128"
+              "room": ""
             },
             {
               "day": "R",
               "time": "11:30",
               "duration": "170",
               "campus": "Keele",
-              "room": "R S128"
+              "room": ""
             }
           ],
           "instructors": [
@@ -26062,7 +26282,7 @@
               "time": "14:30",
               "duration": "170",
               "campus": "Keele",
-              "room": "CFA 312"
+              "room": "DB 2027B"
             }
           ],
           "instructors": [
@@ -26597,26 +26817,9 @@
           "type": "SEMR",
           "meetNumber": "01",
           "section": "A",
-          "catalogNumber": "D25D01 (AP HUMA) Z64D01 (AP JWST) X11M01 (AP RLST)",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "DB 0015"
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "DB 0015"
-            }
-          ],
-          "instructors": [
-            "Marc Herman"
-          ],
+          "catalogNumber": "Cancelled",
+          "schedule": [],
+          "instructors": [],
           "notes": ""
         }
       ]
@@ -26646,6 +26849,43 @@
           ],
           "instructors": [
             "K Weiser"
+          ],
+          "notes": ""
+        }
+      ]
+    },
+    {
+      "faculty": "AP",
+      "department": "JWST",
+      "term": "S1",
+      "courseTitle": "Jews and Muslims",
+      "courseId": "3919",
+      "credits": "3.00",
+      "languageOfInstruction": "EN",
+      "sections": [
+        {
+          "type": "SEMR",
+          "meetNumber": "01",
+          "section": "A",
+          "catalogNumber": "J95M01 (AP HUMA) D42V01 (AP JWST) T89G01 (AP HIST) N36P01 (AP RLST)",
+          "schedule": [
+            {
+              "day": "T",
+              "time": "11:30",
+              "duration": "170",
+              "campus": "Keele",
+              "room": "DB 0015"
+            },
+            {
+              "day": "R",
+              "time": "11:30",
+              "duration": "170",
+              "campus": "Keele",
+              "room": "DB 0015"
+            }
+          ],
+          "instructors": [
+            "Marc Herman"
           ],
           "notes": ""
         }
@@ -26839,14 +27079,14 @@
               "time": "11:30",
               "duration": "170",
               "campus": "Keele",
-              "room": "R S128"
+              "room": ""
             },
             {
               "day": "R",
               "time": "11:30",
               "duration": "170",
               "campus": "Keele",
-              "room": "R S128"
+              "room": ""
             }
           ],
           "instructors": [
@@ -26984,14 +27224,14 @@
               "time": "14:30",
               "duration": "110",
               "campus": "Keele",
-              "room": ""
+              "room": "FRQ 160"
             },
             {
               "day": "W",
               "time": "14:30",
               "duration": "110",
               "campus": "Keele",
-              "room": ""
+              "room": "FRQ 160"
             }
           ],
           "instructors": [],
@@ -27007,14 +27247,14 @@
               "time": "14:30",
               "duration": "110",
               "campus": "Keele",
-              "room": ""
+              "room": "FRQ 164"
             },
             {
               "day": "W",
               "time": "14:30",
               "duration": "110",
               "campus": "Keele",
-              "room": ""
+              "room": "FRQ 164"
             }
           ],
           "instructors": [],
@@ -27129,7 +27369,7 @@
           "instructors": [
             "Kelly M Parr"
           ],
-          "notes": ""
+          "notes": "$35.00 - Course Materials"
         },
         {
           "type": "LAB",
@@ -27220,30 +27460,8 @@
           "type": "ISTY",
           "meetNumber": "01",
           "section": "A",
-          "catalogNumber": "C68U01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "10:30",
-              "duration": "350",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "10:30",
-              "duration": "350",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "F",
-              "time": "10:30",
-              "duration": "350",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
+          "catalogNumber": "Cancelled",
+          "schedule": [],
           "instructors": [],
           "notes": ""
         }
@@ -27551,7 +27769,9 @@
               "room": ""
             }
           ],
-          "instructors": [],
+          "instructors": [
+            "Marnie McRoberts"
+          ],
           "notes": ""
         }
       ]
@@ -28264,7 +28484,7 @@
               "time": "18:00",
               "duration": "170",
               "campus": "Keele",
-              "room": "ACW 206"
+              "room": "VH A"
             }
           ],
           "instructors": [],
@@ -29327,7 +29547,7 @@
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "$75.00 - Course Materials"
         }
       ]
     },
@@ -29355,7 +29575,7 @@
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "$75.00 - Course Materials"
         }
       ]
     },
@@ -29383,7 +29603,7 @@
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "$75.00 - Course Materials"
         }
       ]
     },
@@ -30260,6 +30480,34 @@
       "faculty": "FA",
       "department": "MUSI",
       "term": "S1",
+      "courseTitle": "The Basics of Music",
+      "courseId": "1001",
+      "credits": "3.00",
+      "languageOfInstruction": "EN",
+      "sections": [
+        {
+          "type": "ONLN",
+          "meetNumber": "01",
+          "section": "A",
+          "catalogNumber": "D76M01",
+          "schedule": [
+            {
+              "day": "",
+              "time": "",
+              "duration": "0",
+              "campus": "Keele",
+              "room": ""
+            }
+          ],
+          "instructors": [],
+          "notes": ""
+        }
+      ]
+    },
+    {
+      "faculty": "FA",
+      "department": "MUSI",
+      "term": "S1",
       "courseTitle": "Guitar for Non-Majors and Majors",
       "courseId": "1012",
       "credits": "3.00",
@@ -30317,7 +30565,7 @@
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "$25.00 - Course Materials"
         }
       ]
     },
@@ -30371,27 +30619,12 @@
           "type": "STDO",
           "meetNumber": "01",
           "section": "A",
-          "catalogNumber": "G34A01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "13:30",
-              "duration": "180",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "13:30",
-              "duration": "180",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
+          "catalogNumber": "Cancelled",
+          "schedule": [],
           "instructors": [
             "John Castillo"
           ],
-          "notes": ""
+          "notes": "John Castillo"
         }
       ]
     },
@@ -30478,6 +30711,41 @@
       "faculty": "FA",
       "department": "MUSI",
       "term": "S1",
+      "courseTitle": "Music Production & Engineering",
+      "courseId": "3144",
+      "credits": "6.00",
+      "languageOfInstruction": "EN",
+      "sections": [
+        {
+          "type": "STDO",
+          "meetNumber": "01",
+          "section": "A",
+          "catalogNumber": "K29D01",
+          "schedule": [
+            {
+              "day": "T",
+              "time": "13:30",
+              "duration": "170",
+              "campus": "Keele",
+              "room": ""
+            },
+            {
+              "day": "R",
+              "time": "13:30",
+              "duration": "170",
+              "campus": "Keele",
+              "room": ""
+            }
+          ],
+          "instructors": [],
+          "notes": ""
+        }
+      ]
+    },
+    {
+      "faculty": "FA",
+      "department": "MUSI",
+      "term": "S1",
       "courseTitle": "Music of the Americas",
       "courseId": "3350",
       "credits": "3.00",
@@ -30550,7 +30818,7 @@
             {
               "day": "F",
               "time": "11:30",
-              "duration": "120",
+              "duration": "170",
               "campus": "Keele",
               "room": ""
             }
@@ -30578,7 +30846,7 @@
             {
               "day": "F",
               "time": "11:30",
-              "duration": "120",
+              "duration": "170",
               "campus": "Keele",
               "room": ""
             }
@@ -33017,7 +33285,7 @@
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "(Backup)"
         }
       ]
     },
@@ -33410,6 +33678,62 @@
             "Laura Levin"
           ],
           "notes": ""
+        }
+      ]
+    },
+    {
+      "faculty": "FA",
+      "department": "PANF",
+      "term": "L2",
+      "courseTitle": "C4 Collaborative Project",
+      "courseId": "3999",
+      "credits": "3.00",
+      "languageOfInstruction": "EN",
+      "sections": [
+        {
+          "type": "STDO",
+          "meetNumber": "01",
+          "section": "A",
+          "catalogNumber": "S29R01",
+          "schedule": [
+            {
+              "day": "M",
+              "time": "10:00",
+              "duration": "380",
+              "campus": "Keele",
+              "room": ""
+            },
+            {
+              "day": "T",
+              "time": "10:00",
+              "duration": "380",
+              "campus": "Keele",
+              "room": ""
+            },
+            {
+              "day": "W",
+              "time": "10:00",
+              "duration": "380",
+              "campus": "Keele",
+              "room": ""
+            },
+            {
+              "day": "R",
+              "time": "10:00",
+              "duration": "380",
+              "campus": "Keele",
+              "room": ""
+            },
+            {
+              "day": "F",
+              "time": "10:00",
+              "duration": "380",
+              "campus": "Keele",
+              "room": ""
+            }
+          ],
+          "instructors": [],
+          "notes": "This offering is part of the Cross-Campus Capstone Classroom (C4) Launchpad program. From June 1 to June 12 (with Capstone Day on June 19), students will work in interdisciplinary teams on a project sprint focused on real-world social impact. To apply, visit https://www.yorku.ca/c4/apply-for-c4/ ."
         }
       ]
     },
@@ -34541,11 +34865,11 @@
               "time": "9:30",
               "duration": "170",
               "campus": "Keele",
-              "room": "BC 102D"
+              "room": ""
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "(Backup)"
         },
         {
           "type": "LAB",
@@ -34573,11 +34897,11 @@
               "time": "9:30",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "BC 102D"
             }
           ],
           "instructors": [],
-          "notes": "(Backup)"
+          "notes": ""
         },
         {
           "type": "LAB",
@@ -34637,11 +34961,11 @@
               "time": "9:30",
               "duration": "170",
               "campus": "Keele",
-              "room": "BC 102D"
+              "room": ""
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "(Backup)"
         },
         {
           "type": "LAB",
@@ -34673,7 +34997,7 @@
             }
           ],
           "instructors": [],
-          "notes": "(Backup)"
+          "notes": ""
         },
         {
           "type": "LAB",
@@ -34732,10366 +35056,2320 @@
       "department": "PHYS",
       "term": "SU",
       "courseTitle": "Introduction to Physics",
-      "courseId": "1510",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "10:00",
-              "duration": "80",
-              "campus": "Keele",
-              "room": "ACW 005"
-            },
-            {
-              "day": "R",
-              "time": "10:00",
-              "duration": "80",
-              "campus": "Keele",
-              "room": "ACW 005"
-            }
-          ],
-          "instructors": [
-            "Jesse Rogerson"
-          ],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "01",
-          "catalogNumber": "T70R02",
-          "schedule": [
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "80",
-              "campus": "Keele",
-              "room": "ACW 005"
-            }
-          ],
-          "instructors": [
-            "Jesse Rogerson"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "SC",
       "department": "PHYS",
       "term": "SU",
       "courseTitle": "Electricity, Magnetism and Optics for Engineers",
-      "courseId": "1801",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "12:00",
-              "duration": "80",
-              "campus": "Keele",
-              "room": "ACW 109"
-            },
-            {
-              "day": "W",
-              "time": "12:00",
-              "duration": "80",
-              "campus": "Keele",
-              "room": "ACW 109"
-            }
-          ],
-          "instructors": [
-            "Pour Banafsheh Hashemi"
-          ],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "01",
-          "catalogNumber": "",
-          "schedule": [
-            {
-              "day": "R",
-              "time": "12:00",
-              "duration": "50",
-              "campus": "Keele",
-              "room": "LAS A"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "LAB",
-          "meetNumber": "01",
-          "catalogNumber": "N17D03",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "BC 102F"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "LAB",
-          "meetNumber": "02",
-          "catalogNumber": "N17D04",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "BC 102F"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "LAB",
-          "meetNumber": "03",
-          "catalogNumber": "N17D05",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "BC 102F"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "LAB",
-          "meetNumber": "04",
-          "catalogNumber": "N17D06",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "15:00",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "BC 102F"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "LAB",
-          "meetNumber": "05",
-          "catalogNumber": "N17D07",
-          "schedule": [
-            {
-              "day": "W",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "BC 102F"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "LAB",
-          "meetNumber": "06",
-          "catalogNumber": "N17D08",
-          "schedule": [
-            {
-              "day": "W",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "BC 102F"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "LAB",
-          "meetNumber": "07",
-          "catalogNumber": "N17D09",
-          "schedule": [
-            {
-              "day": "R",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "BC 102F"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "LAB",
-          "meetNumber": "08",
-          "catalogNumber": "N17D10",
-          "schedule": [
-            {
-              "day": "F",
-              "time": "9:00",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "BC 102F"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "LAB",
-          "meetNumber": "09",
-          "catalogNumber": "N17D11",
-          "schedule": [
-            {
-              "day": "F",
-              "time": "11:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "BC 102F"
-            }
-          ],
-          "instructors": [],
-          "notes": "(Backup)"
-        },
-        {
-          "type": "LAB",
-          "meetNumber": "99",
-          "catalogNumber": "N17D12",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "SC",
       "department": "PHYS",
       "term": "SU",
       "courseTitle": "Electricity and Magnetism",
-      "courseId": "2020",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "TUTR",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "",
-          "schedule": [
-            {
-              "day": "W",
-              "time": "16:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Sean Tulin"
-          ],
-          "notes": ""
-        },
-        {
-          "type": "ONCA",
-          "meetNumber": "01",
-          "catalogNumber": "G64M01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "15:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "15:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "F",
-              "time": "15:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Sean Tulin"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "SC",
       "department": "PHYS",
       "term": "SU",
       "courseTitle": "Physics Internship Work Term",
-      "courseId": "3900",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "INSP",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "Q29Z01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "SC",
       "department": "PHYS",
       "term": "S1",
       "courseTitle": "Physics or Astronomy Project",
-      "courseId": "4310",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ISTY",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "M88Y01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "SC",
       "department": "PHYS",
       "term": "S2",
       "courseTitle": "Physics or Astronomy Project",
-      "courseId": "4310",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ISTY",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "G35U01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "SC",
       "department": "PHYS",
       "term": "SU",
       "courseTitle": "Physics or Astronomy Project",
-      "courseId": "4310",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ISTY",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "W82F01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PKIN",
       "term": "S1",
       "courseTitle": "Swimming I",
-      "courseId": "0200",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "S28Q01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "13:30",
-              "duration": "80",
-              "campus": "Keele",
-              "room": "TM POOL"
-            },
-            {
-              "day": "R",
-              "time": "13:30",
-              "duration": "80",
-              "campus": "Keele",
-              "room": "TM POOL"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "B",
-          "catalogNumber": "Y75C01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "15:00",
-              "duration": "80",
-              "campus": "Keele",
-              "room": "TM POOL"
-            },
-            {
-              "day": "R",
-              "time": "15:00",
-              "duration": "80",
-              "campus": "Keele",
-              "room": "TM POOL"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PKIN",
       "term": "S2",
       "courseTitle": "Swimming I",
-      "courseId": "0200",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "F22Y01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "10:00",
-              "duration": "80",
-              "campus": "Keele",
-              "room": "TM POOL"
-            },
-            {
-              "day": "W",
-              "time": "10:00",
-              "duration": "80",
-              "campus": "Keele",
-              "room": "TM POOL"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PKIN",
       "term": "S1",
       "courseTitle": "Sports Conditioning in an Aquatic Environment",
-      "courseId": "0286",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "B81X01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "8:30",
-              "duration": "80",
-              "campus": "Keele",
-              "room": "TM POOL"
-            },
-            {
-              "day": "R",
-              "time": "8:30",
-              "duration": "80",
-              "campus": "Keele",
-              "room": "TM POOL"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PKIN",
       "term": "S1",
       "courseTitle": "Pre-Swim I",
-      "courseId": "0295",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "G89Q01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "8:30",
-              "duration": "80",
-              "campus": "Keele",
-              "room": "TM POOL"
-            },
-            {
-              "day": "W",
-              "time": "8:30",
-              "duration": "80",
-              "campus": "Keele",
-              "room": "TM POOL"
-            }
-          ],
-          "instructors": [
-            "Nicole Ferguson"
-          ],
-          "notes": ""
-        },
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "B",
-          "catalogNumber": "A36C01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "10:00",
-              "duration": "80",
-              "campus": "Keele",
-              "room": "TM POOL"
-            },
-            {
-              "day": "W",
-              "time": "10:00",
-              "duration": "80",
-              "campus": "Keele",
-              "room": "TM POOL"
-            }
-          ],
-          "instructors": [
-            "Nicole Ferguson"
-          ],
-          "notes": ""
-        },
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "C",
-          "catalogNumber": "Q83K01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "13:30",
-              "duration": "80",
-              "campus": "Keele",
-              "room": "TM POOL"
-            },
-            {
-              "day": "W",
-              "time": "13:30",
-              "duration": "80",
-              "campus": "Keele",
-              "room": "TM POOL"
-            }
-          ],
-          "instructors": [
-            "Nicole Ferguson"
-          ],
-          "notes": "Women's Only"
-        },
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "D",
-          "catalogNumber": "K30T01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "15:00",
-              "duration": "80",
-              "campus": "Keele",
-              "room": "TM POOL"
-            },
-            {
-              "day": "W",
-              "time": "15:00",
-              "duration": "80",
-              "campus": "Keele",
-              "room": "TM POOL"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PKIN",
       "term": "S2",
       "courseTitle": "Pre-Swim I",
-      "courseId": "0295",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "D77F01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "8:30",
-              "duration": "80",
-              "campus": "Keele",
-              "room": "TM POOL"
-            },
-            {
-              "day": "R",
-              "time": "8:30",
-              "duration": "80",
-              "campus": "Keele",
-              "room": "TM POOL"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "N",
-          "catalogNumber": "U24N01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "10:00",
-              "duration": "80",
-              "campus": "Keele",
-              "room": "TM POOL"
-            },
-            {
-              "day": "R",
-              "time": "10:00",
-              "duration": "80",
-              "campus": "Keele",
-              "room": "TM POOL"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PKIN",
       "term": "S1",
       "courseTitle": "Co-ed Basketball I",
-      "courseId": "0301",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "W49C01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM UPPGYM"
-            },
-            {
-              "day": "R",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM UPPGYM"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "B",
-          "catalogNumber": "P96Y01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM UPPGYM"
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM UPPGYM"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PKIN",
       "term": "S2",
       "courseTitle": "Co-ed Basketball I",
-      "courseId": "0301",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "J43U01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM UPPGYM"
-            },
-            {
-              "day": "R",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM UPPGYM"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "N",
-          "catalogNumber": "C90G01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM UPPGYM"
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM UPPGYM"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PKIN",
       "term": "S1",
       "courseTitle": "Football I",
-      "courseId": "0308",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "N71W01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Tom Gretes"
-          ],
-          "notes": "Will be on the South Utility Field"
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PKIN",
       "term": "S1",
       "courseTitle": "Soccer I",
-      "courseId": "0328",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "H18X01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "Will be held on the Football Field"
-        },
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "B",
-          "catalogNumber": "A65R01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "Will be held on the Football Field"
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PKIN",
       "term": "S1",
       "courseTitle": "Volleyball I",
-      "courseId": "0332",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "R12C01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM MNGYM"
-            },
-            {
-              "day": "R",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM MNGYM"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "B",
-          "catalogNumber": "K59Y01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM MNGYM"
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM MNGYM"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "C",
-          "catalogNumber": "E06U01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "13:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM MNGYM"
-            },
-            {
-              "day": "R",
-              "time": "13:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM MNGYM"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PKIN",
       "term": "S1",
       "courseTitle": "Softball",
-      "courseId": "0340",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "U53F01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "11:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Tom Gretes"
-          ],
-          "notes": "Will be held on the Passy Field #2"
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PKIN",
       "term": "S1",
       "courseTitle": "Frisbee Sports: Competitive & Cooperative Disc Sports",
-      "courseId": "0370",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "E93T01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "10:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "10:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "Will be held on the South Utility Field"
-        },
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "B",
-          "catalogNumber": "V40E01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "Will be held on the South Utility Field"
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PKIN",
       "term": "S2",
       "courseTitle": "Frisbee Sports: Competitive & Cooperative Disc Sports",
-      "courseId": "0370",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "Z87N01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "Will be held on the South Utility Field"
-        },
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "N",
-          "catalogNumber": "X34W01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "Will be held on the South Utility Field"
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PKIN",
       "term": "S1",
       "courseTitle": "Games Through the Ages",
-      "courseId": "0392",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "B52Q01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "Will be held on the South Utility Field"
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PKIN",
       "term": "S1",
       "courseTitle": "Tai Chi I",
-      "courseId": "0400",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "Z00Z01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "8:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM STUDIO2"
-            },
-            {
-              "day": "W",
-              "time": "8:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM STUDIO2"
-            }
-          ],
-          "instructors": [
-            "Antonio Santilli"
-          ],
-          "notes": ""
-        },
-        {
-          "type": "STDO",
-          "meetNumber": "",
-          "catalogNumber": "",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "STDO",
-          "meetNumber": "",
-          "catalogNumber": "",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PKIN",
       "term": "S2",
       "courseTitle": "Yoga I",
-      "courseId": "0402",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "H47A01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM STUDIO6"
-            },
-            {
-              "day": "W",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM STUDIO6"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "STDO",
-          "meetNumber": "",
-          "catalogNumber": "",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "STDO",
-          "meetNumber": "",
-          "catalogNumber": "",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "N",
-          "catalogNumber": "A94J01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM STUDIO6"
-            },
-            {
-              "day": "W",
-              "time": "11:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM STUDIO6"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "STDO",
-          "meetNumber": "",
-          "catalogNumber": "",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "STDO",
-          "meetNumber": "",
-          "catalogNumber": "",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "O",
-          "catalogNumber": "R41R01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM STUDIO4"
-            },
-            {
-              "day": "R",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM STUDIO4"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "STDO",
-          "meetNumber": "",
-          "catalogNumber": "",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "STDO",
-          "meetNumber": "",
-          "catalogNumber": "",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "P",
-          "catalogNumber": "K88D01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM STUDIO4"
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM STUDIO4"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "STDO",
-          "meetNumber": "",
-          "catalogNumber": "",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "STDO",
-          "meetNumber": "",
-          "catalogNumber": "",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PKIN",
       "term": "S2",
       "courseTitle": "Pilates: Restorative",
-      "courseId": "0403",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "R99B01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "10:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "10:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Lisa Sandlos"
-          ],
-          "notes": ""
-        },
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "N",
-          "catalogNumber": "Y46K01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Lisa Sandlos"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PKIN",
       "term": "S1",
       "courseTitle": "Pilates",
-      "courseId": "0405",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "T95V01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "10:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM STUDIO6"
-            },
-            {
-              "day": "R",
-              "time": "10:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM STUDIO6"
-            }
-          ],
-          "instructors": [
-            "Lisa Sandlos"
-          ],
-          "notes": ""
-        },
-        {
-          "type": "STDO",
-          "meetNumber": "",
-          "catalogNumber": "",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "STDO",
-          "meetNumber": "",
-          "catalogNumber": "",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "B",
-          "catalogNumber": "N42H01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM STUDIO6"
-            },
-            {
-              "day": "R",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM STUDIO6"
-            }
-          ],
-          "instructors": [
-            "Lisa Sandlos"
-          ],
-          "notes": ""
-        },
-        {
-          "type": "STDO",
-          "meetNumber": "",
-          "catalogNumber": "",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "STDO",
-          "meetNumber": "",
-          "catalogNumber": "",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PKIN",
       "term": "S1",
       "courseTitle": "Tennis I",
-      "courseId": "0435",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "W78R01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "Will be in the Tait Tennis Courts"
-        },
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "B",
-          "catalogNumber": "Q25D01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "Will be in the Tait Tennis Courts"
-        },
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "C",
-          "catalogNumber": "J72M01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "13:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "13:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "Will be in the Tait Tennis Courts"
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PKIN",
       "term": "S1",
       "courseTitle": "Badminton I",
-      "courseId": "0440",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "E35M01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM MNGYM"
-            },
-            {
-              "day": "W",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM MNGYM"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "B",
-          "catalogNumber": "U82U01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM MNGYM"
-            },
-            {
-              "day": "W",
-              "time": "11:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM MNGYM"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PKIN",
       "term": "S1",
       "courseTitle": "Strength Training",
-      "courseId": "0460",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "Z29G01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TFC 115B"
-            },
-            {
-              "day": "W",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TFC 115B"
-            }
-          ],
-          "instructors": [
-            "Tom Gretes"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PKIN",
       "term": "S2",
       "courseTitle": "Strength Training",
-      "courseId": "0460",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "H76P01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TFC 115B"
-            },
-            {
-              "day": "R",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TFC 115B"
-            }
-          ],
-          "instructors": [
-            "Tom Gretes"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PKIN",
       "term": "S1",
       "courseTitle": "Basic Movement",
-      "courseId": "0500",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "B23B01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM STUDIO4"
-            },
-            {
-              "day": "R",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM STUDIO4"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "STDO",
-          "meetNumber": "",
-          "catalogNumber": "",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "STDO",
-          "meetNumber": "",
-          "catalogNumber": "",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PKIN",
       "term": "S2",
       "courseTitle": "Dance in Movies and Videos of Popular Culture",
-      "courseId": "0562",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "N",
-          "catalogNumber": "X05H01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "13:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM STUDIO4"
-            },
-            {
-              "day": "W",
-              "time": "13:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM STUDIO4"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "STDO",
-          "meetNumber": "",
-          "catalogNumber": "",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "STDO",
-          "meetNumber": "",
-          "catalogNumber": "",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PKIN",
       "term": "S1",
       "courseTitle": "Track and Field I",
-      "courseId": "0600",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "R70J01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TFC 115A"
-            },
-            {
-              "day": "W",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TFC 115A"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "B",
-          "catalogNumber": "Y17S01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TFC 115A"
-            },
-            {
-              "day": "W",
-              "time": "11:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TFC 115A"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "C",
-          "catalogNumber": "E64E01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TFC 115A"
-            },
-            {
-              "day": "R",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TFC 115A"
-            }
-          ],
-          "instructors": [
-            "Tom Gretes"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PKIN",
       "term": "S2",
       "courseTitle": "Track and Field I",
-      "courseId": "0600",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "V11M01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TFC 115A"
-            },
-            {
-              "day": "W",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TFC 115A"
-            }
-          ],
-          "instructors": [
-            "Tom Gretes"
-          ],
-          "notes": ""
-        },
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "N",
-          "catalogNumber": "Z58V01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TFC 115A"
-            },
-            {
-              "day": "W",
-              "time": "11:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TFC 115A"
-            }
-          ],
-          "instructors": [
-            "Tom Gretes"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PKIN",
       "term": "S1",
       "courseTitle": "Emergency Care I",
-      "courseId": "0750",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "D19V01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "SC 101A"
-            },
-            {
-              "day": "W",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "SC 101A"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "B",
-          "catalogNumber": "T66G01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "SC 101A"
-            },
-            {
-              "day": "W",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "SC 101A"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "C",
-          "catalogNumber": "N13P01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "8:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "SC 101A"
-            },
-            {
-              "day": "R",
-              "time": "8:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "SC 101A"
-            }
-          ],
-          "instructors": [
-            "Nicole Ferguson"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PKIN",
       "term": "S2",
       "courseTitle": "Emergency Care I",
-      "courseId": "0750",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "G60B01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "10:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "SC 101A"
-            },
-            {
-              "day": "R",
-              "time": "10:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "SC 101A"
-            }
-          ],
-          "instructors": [
-            "Nicole Ferguson"
-          ],
-          "notes": ""
-        },
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "N",
-          "catalogNumber": "A07K01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "SC 101A"
-            },
-            {
-              "day": "R",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "SC 101A"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "O",
-          "catalogNumber": "Q54S01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "8:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "SC 101A"
-            },
-            {
-              "day": "R",
-              "time": "8:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "SC 101A"
-            }
-          ],
-          "instructors": [
-            "Nicole Ferguson"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PKIN",
       "term": "S1",
       "courseTitle": "Advanced First Aid/CPR",
-      "courseId": "0751",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "G31J01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "8:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "SC 101A"
-            },
-            {
-              "day": "W",
-              "time": "8:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "SC 101A"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PKIN",
       "term": "S1",
       "courseTitle": "First Aid/CPR Instructor",
-      "courseId": "0770",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "K01E01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "10:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "SC 101A"
-            },
-            {
-              "day": "W",
-              "time": "10:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "SC 101A"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PKIN",
       "term": "S2",
       "courseTitle": "Elementary and Recreational Games",
-      "courseId": "0840",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "D48N01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "13:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM MNGYM"
-            },
-            {
-              "day": "W",
-              "time": "13:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "TM MNGYM"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "POLS",
       "term": "SU",
       "courseTitle": "Perspectives on Politics: Classics of Political Thought",
-      "courseId": "2000",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "TUTR",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "F75B02",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "This course will be delivered in ONCA format. Lectures will be online synchronous on Tuesday and Thursday at 12:30 PM. Tutorials will be online synchronous on the Day(s) and Start Time listed here. Tests/exams are in-person. Additional information will be provided by your course instructor."
-        },
-        {
-          "type": "ONCA",
-          "meetNumber": "01",
-          "catalogNumber": "",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "02",
-          "catalogNumber": "F75B03",
-          "schedule": [
-            {
-              "day": "R",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "03",
-          "catalogNumber": "F75B04",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "16:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "04",
-          "catalogNumber": "F75B05",
-          "schedule": [
-            {
-              "day": "R",
-              "time": "16:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "POLS",
       "term": "S1",
       "courseTitle": "Introduction to Canadian Politics",
-      "courseId": "2100",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "ACW 006"
-            },
-            {
-              "day": "F",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "ACW 006"
-            }
-          ],
-          "instructors": [],
-          "notes": "This course will meet in person in the location assigned. The Lecture and Tutorials will be in person on the Day(s) and Start Time listed here."
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "01",
-          "catalogNumber": "C09M02",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "DB 0009"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "02",
-          "catalogNumber": "C09M03",
-          "schedule": [
-            {
-              "day": "F",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "ACE 012"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "03",
-          "catalogNumber": "C09M04",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "16:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "R S205"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "04",
-          "catalogNumber": "C09M05",
-          "schedule": [
-            {
-              "day": "F",
-              "time": "16:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "R S128"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "POLS",
       "term": "S1",
       "courseTitle": "Communities and Public Law",
-      "courseId": "2200",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "X30G01 (AP PPAS) M58X01 (AP POLS)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Danny O'Rourke-DiCarlo"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "POLS",
       "term": "S1",
       "courseTitle": "Introduction to Comparative Politics",
-      "courseId": "2400",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "TUTR",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "M03G02 (AP POLS) Z06T02 (AP GLBL)",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "10:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "The Lecture and tutorials for this course will be delivered fully online. Lecture is Aynchronous. Tutorials are Synchronous on the days and times provided. Additional information will be provided by your course instructor."
-        },
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "catalogNumber": "",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "02",
-          "catalogNumber": "M03G03 (AP POLS) Z06T03 (AP GLBL)",
-          "schedule": [
-            {
-              "day": "R",
-              "time": "10:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "03",
-          "catalogNumber": "M03G04 (AP POLS) Z06T04 (AP GLBL)",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "13:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "04",
-          "catalogNumber": "M03G05 (AP POLS) Z06T05 (AP GLBL)",
-          "schedule": [
-            {
-              "day": "R",
-              "time": "13:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "POLS",
       "term": "S1",
       "courseTitle": "Public Law I: The Constitution and the Courts in Canada",
-      "courseId": "3135",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "S24A01 (AP POLS) W23K01 (AP PPAS) G05R01 (GL POLS)",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "HNE 031"
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "HNE 031"
-            }
-          ],
-          "instructors": [
-            "Danny O'Rourke-DiCarlo"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "POLS",
       "term": "S2",
       "courseTitle": "Public Law I: The Constitution and the Courts in Canada",
-      "courseId": "3135",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "Y71J01 (AP POLS) P70T01 (AP PPAS) W52C01 (GL POLS)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "19:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "19:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Danny O'Rourke-DiCarlo"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "GL",
       "department": "POLS",
       "term": "S1",
       "courseTitle": "Public Law I: The Constitution and the Courts in Canada",
-      "courseId": "3135",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "S24A01 (AP POLS) W23K01 (AP PPAS) G05R01 (GL POLS)",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "HNE 031"
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "HNE 031"
-            }
-          ],
-          "instructors": [
-            "Danny O'Rourke-DiCarlo"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "GL",
       "department": "POLS",
       "term": "S2",
       "courseTitle": "Public Law I: The Constitution and the Courts in Canada",
-      "courseId": "3135",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "Y71J01 (AP POLS) P70T01 (AP PPAS) W52C01 (GL POLS)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "19:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "19:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Danny O'Rourke-DiCarlo"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "POLS",
       "term": "S1",
       "courseTitle": "Public Law II: The Charter of Rights and Freedoms and the Limits of Public Administration",
-      "courseId": "3136",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "F18S01 (AP POLS) J17F01 (AP PPAS) P99Y01 (GL POLS)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "19:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "19:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "POLS",
       "term": "S2",
       "courseTitle": "Public Law II: The Charter of Rights and Freedoms and the Limits of Public Administration",
-      "courseId": "3136",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "V65D01 (AP POLS) C64Z01 (AP PPAS) J46U01 (GL POLS)",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "HNE 031"
-            },
-            {
-              "day": "R",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "HNE 031"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "GL",
       "department": "POLS",
       "term": "S1",
       "courseTitle": "Public Law II: The Charter of Rights and Freedoms and the Limits of Public Administration",
-      "courseId": "3136",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "F18S01 (AP POLS) J17F01 (AP PPAS) P99Y01 (GL POLS)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "19:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "19:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "GL",
       "department": "POLS",
       "term": "S2",
       "courseTitle": "Public Law II: The Charter of Rights and Freedoms and the Limits of Public Administration",
-      "courseId": "3136",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "V65D01 (AP POLS) C64Z01 (AP PPAS) J46U01 (GL POLS)",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "HNE 031"
-            },
-            {
-              "day": "R",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "HNE 031"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "POLS",
       "term": "S3",
       "courseTitle": "Public Administration",
-      "courseId": "3190",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "N96V01 (AP PPAS) M00B01 (AP POLS)",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "POLS",
       "term": "S2",
       "courseTitle": "The Political Economy of Newly-Industrialized Countries",
-      "courseId": "3411",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "N82H01 (AP POLS) H29Q01 (AP GLBL)",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "10:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "10:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "This course will be delivered in ONLN format. Lectures will be online synchronous on Tues. & Thurs. at 10:30 a.m."
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "POLS",
       "term": "S1",
       "courseTitle": "Political Economy of Asia and Pacific",
-      "courseId": "3591",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "U35V01 (AP POLS) D88N01 (AP GLBL)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "10:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "HNE 032"
-            },
-            {
-              "day": "W",
-              "time": "10:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "HNE 032"
-            }
-          ],
-          "instructors": [],
-          "notes": "This course will meet in person in the location assigned as per the Day(s) and Start Time listed here."
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "GL",
       "department": "POLS",
       "term": "SU",
       "courseTitle": "Politics of the Middle East and North Africa",
-      "courseId": "3686",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "G51Z01 (GL POLS) U15D01 (GL ILST)",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "18:00",
-              "duration": "170",
-              "campus": "Glendon",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "POLS",
       "term": "S1",
       "courseTitle": "Supervised Reading and Research",
-      "courseId": "3990",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "DIRD",
-          "meetNumber": "01",
-          "section": "B",
-          "catalogNumber": "K87P01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "POLS",
       "term": "S2",
       "courseTitle": "Supervised Reading and Research",
-      "courseId": "3990",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "DIRD",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "E34B01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "POLS",
       "term": "SU",
       "courseTitle": "Supervised Reading and Research",
-      "courseId": "3990",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "DIRD",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "U81J01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "POLS",
       "term": "SU",
       "courseTitle": "Supervised Reading and Research",
-      "courseId": "3990",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "DIRD",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "Z28S01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "POLS",
       "term": "S1",
       "courseTitle": "Encounters of Islam and Modernity",
-      "courseId": "4075",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "R40G01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH 3003"
-            },
-            {
-              "day": "W",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH 3003"
-            }
-          ],
-          "instructors": [],
-          "notes": "This course will meet in person in the location assigned. The Seminar will be in person on the Day(s) and Start Time listed here."
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "POLS",
       "term": "SU",
       "courseTitle": "Politics, Law and the Courts",
-      "courseId": "4130",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "SEMR",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "Z83U01 (AP PPAS) T11W01 (AP POLS)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "FC 114"
-            },
-            {
-              "day": "W",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "FC 114"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "POLS",
       "term": "S1",
       "courseTitle": "Human Security, Global Capitalism and the Biosphere",
-      "courseId": "4261",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "V97A01 (AP POLS) B00Z01 (AP GLBL)",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "This course will be delievered fully online in an Asynchronous format. Additional information will be provided by your course instructor."
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "POLS",
       "term": "S1",
       "courseTitle": "Global Political Economy and the Making of World Orders",
-      "courseId": "4287",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "P44J01 (AP POLS) R47W01 (AP GLBL)",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "This course will be delievered fully online in an Asynchronous format. Additional information will be provided by your course instructor."
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "POLS",
       "term": "S1",
       "courseTitle": "Patterns and Problems of Globalization",
-      "courseId": "4293",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "X91S01 (AP POLS) K94X01 (AP GLBL)",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "POLS",
       "term": "S1",
       "courseTitle": "Gender-Responsive and Participatory Budgeting: Canadian and International Experiences",
-      "courseId": "4296",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "C38E01 (AP POLS) E41R01 (AP GLBL)",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "This course will be delievered fully online in an Asynchronous format. Additional information will be provided by your course instructor."
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "GL",
       "department": "POLS",
       "term": "D2",
       "courseTitle": "Political Immersion Abroad Summer Course",
-      "courseId": "4400",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "D10Y01 (GL POLS) K21J01 (GL CORE)",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Glendon",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Willem Maas"
-          ],
-          "notes": "The summer 2026 course is full. Please monitor https://www.yorku.ca/international/global-learning/faculty-led-study-abroad-courses/pols4400/ for details about how to register for the summer 2027 version, or reach out to yuabroad@yorku.ca ."
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "GL",
       "department": "POLS",
       "term": "SU",
       "courseTitle": "Professional Work Placement / Placement en milieu de travail",
-      "courseId": "4975",
-      "credits": "3.00",
-      "languageOfInstruction": "BI",
-      "sections": [
-        {
-          "type": "BLEN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "W98W01 (GL SOSC) N62M01 (GL POLS)",
-          "schedule": [
-            {
-              "day": "F",
-              "time": "13:00",
-              "duration": "110",
-              "campus": "Glendon",
-              "room": "YH A201"
-            }
-          ],
-          "instructors": [
-            "Audrey Pyee"
-          ],
-          "notes": "There will NOT be weekly classes, but some synchronous online or in-person meetings a few times during the session will be required. / Il n'y aura PAS de cours hebdomadaires. Quelques cours en ligne (synchrones) ou en personne seront nécessaires quelques fois pendant la session."
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "POLS",
       "term": "SU",
       "courseTitle": "Supervised Reading and Research",
-      "courseId": "4990",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "DIRD",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "H75E01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "POLS",
       "term": "S1",
       "courseTitle": "Supervised Reading and Research",
-      "courseId": "4990",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "DIRD",
-          "meetNumber": "01",
-          "section": "B",
-          "catalogNumber": "B22N01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "POLS",
       "term": "S2",
       "courseTitle": "Supervised Reading and Research",
-      "courseId": "4990",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "DIRD",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "R69V01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "POLS",
       "term": "SU",
       "courseTitle": "Supervised Reading and Research",
-      "courseId": "4990",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "DIRD",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "Y16H01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "POR",
       "term": "SU",
       "courseTitle": "Elementary Portuguese",
-      "courseId": "1000",
-      "credits": "6.00",
-      "languageOfInstruction": "PE",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "T45E01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "16:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "16:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Patricia Duarte Vieira"
-          ],
-          "notes": "Please complete the online Portuguese placement test ."
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "PPAS",
       "term": "S1",
       "courseTitle": "Canadian Government",
-      "courseId": "2110",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "E31T01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "PPAS",
       "term": "S1",
       "courseTitle": "Communities and Public Law",
-      "courseId": "2200",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "X30G01 (AP PPAS) M58X01 (AP POLS)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Danny O'Rourke-DiCarlo"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "PPAS",
       "term": "S1",
       "courseTitle": "Public Law I: The Constitution and the Courts in Canada",
-      "courseId": "3135",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "S24A01 (AP POLS) W23K01 (AP PPAS) G05R01 (GL POLS)",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "HNE 031"
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "HNE 031"
-            }
-          ],
-          "instructors": [
-            "Danny O'Rourke-DiCarlo"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "PPAS",
       "term": "S2",
       "courseTitle": "Public Law I: The Constitution and the Courts in Canada",
-      "courseId": "3135",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "Y71J01 (AP POLS) P70T01 (AP PPAS) W52C01 (GL POLS)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "19:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "19:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Danny O'Rourke-DiCarlo"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "PPAS",
       "term": "S1",
       "courseTitle": "Public Law II: The Charter of Rights and Freedoms and the Limits of Public Administration",
-      "courseId": "3136",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "F18S01 (AP POLS) J17F01 (AP PPAS) P99Y01 (GL POLS)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "19:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "19:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "PPAS",
       "term": "S2",
       "courseTitle": "Public Law II: The Charter of Rights and Freedoms and the Limits of Public Administration",
-      "courseId": "3136",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "V65D01 (AP POLS) C64Z01 (AP PPAS) J46U01 (GL POLS)",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "HNE 031"
-            },
-            {
-              "day": "R",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "HNE 031"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "PPAS",
       "term": "S3",
       "courseTitle": "Public Administration",
-      "courseId": "3190",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "N96V01 (AP PPAS) M00B01 (AP POLS)",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "PPAS",
       "term": "S1",
       "courseTitle": "Directed Reading/Special Study",
-      "courseId": "4000",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "DIRD",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "H43H01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "PPAS",
       "term": "S2",
       "courseTitle": "Directed Reading/Special Study",
-      "courseId": "4000",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "DIRD",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "A90Q01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "PPAS",
       "term": "SU",
       "courseTitle": "Directed Reading/Special Study",
-      "courseId": "4000",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "DIRD",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "R37B01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "PPAS",
       "term": "SU",
       "courseTitle": "Sociology of Law",
-      "courseId": "4070",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "B77P01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Thaddeus Hwong"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "PPAS",
       "term": "SU",
       "courseTitle": "Regional Economic Development",
-      "courseId": "4110",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "BLEN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "K84K01 (AP PPAS) F47K01 (AP ECON)",
-          "schedule": [
-            {
-              "day": "R",
-              "time": "19:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "This course will be offered through a combination of online instruction and in-person classes at the day/time indicated. Additional information will be provided by the course instructor on the course outline."
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "PPAS",
       "term": "SU",
       "courseTitle": "Politics, Law and the Courts",
-      "courseId": "4130",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "SEMR",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "Z83U01 (AP PPAS) T11W01 (AP POLS)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "FC 114"
-            },
-            {
-              "day": "W",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "FC 114"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "SU",
       "courseTitle": "Introduction to Psychology",
-      "courseId": "1010",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "H96G01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH C"
-            },
-            {
-              "day": "W",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH C"
-            }
-          ],
-          "instructors": [
-            "Agnieszka Kopinska"
-          ],
-          "notes": ""
-        },
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "B",
-          "catalogNumber": "B43P01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Alisha Salerno"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "S1",
       "courseTitle": "Writing in Psychology",
-      "courseId": "2010",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "M75W01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "ACW 106"
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "ACW 106"
-            }
-          ],
-          "instructors": [
-            "Julie Conder"
-          ],
-          "notes": ""
-        },
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "B",
-          "catalogNumber": "G22X01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "8:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "8:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Jean Varghese"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "S2",
       "courseTitle": "Writing in Psychology",
-      "courseId": "2010",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "W69Q01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "19:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "FC 203"
-            },
-            {
-              "day": "W",
-              "time": "19:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "FC 203"
-            }
-          ],
-          "instructors": [
-            "Jean Varghese"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "S1",
       "courseTitle": "Statistical Methods I",
-      "courseId": "2021",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "V60S01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH B"
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH B"
-            }
-          ],
-          "instructors": [
-            "Rachel Rabi"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "S2",
       "courseTitle": "Statistical Methods II",
-      "courseId": "2022",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "P07E01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "LAS C"
-            },
-            {
-              "day": "W",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "LAS C"
-            }
-          ],
-          "instructors": [
-            "Corey Petsnik"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "S1",
       "courseTitle": "Introduction to Research Methods",
-      "courseId": "2030",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONCA",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "Y37J01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Heather L. Jenkin"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "S1",
       "courseTitle": "Developmental Psychology",
-      "courseId": "2110",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONCA",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "D97T01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Thanujeni Pathman"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "S1",
       "courseTitle": "Personality",
-      "courseId": "2130",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONCA",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "S19P01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "19:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "19:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Krista Phillips"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "S1",
       "courseTitle": "Motivation",
-      "courseId": "2230",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "X54N01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH B"
-            },
-            {
-              "day": "W",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH B"
-            }
-          ],
-          "instructors": [
-            "Jennifer Ruttle"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "S2",
       "courseTitle": "Biological Basis of Behaviour",
-      "courseId": "2240",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "U44E01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH B"
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH B"
-            }
-          ],
-          "instructors": [
-            "Agnieszka Kopinska"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "S2",
       "courseTitle": "Cognition",
-      "courseId": "2260",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONCA",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "N91N01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Liya Ma"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "S1",
       "courseTitle": "Intermediate Research Methods",
-      "courseId": "3010",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "Y15Z01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Zoha Ahmad"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "S1",
       "courseTitle": "Psychological Health, Distress, & Impairment",
-      "courseId": "3140",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "E84S01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Peter Papadogiannis"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "S2",
       "courseTitle": "Psychological Health, Distress, & Impairment",
-      "courseId": "3140",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "V31D01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH C"
-            },
-            {
-              "day": "R",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH C"
-            }
-          ],
-          "instructors": [
-            "Jennifer Lewin"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "S1",
       "courseTitle": "Animal Behaviour",
-      "courseId": "3280",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "R90A01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH B"
-            },
-            {
-              "day": "R",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH B"
-            }
-          ],
-          "instructors": [
-            "Suzanne MacDonald"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "S1",
       "courseTitle": "Psycholinguistics",
-      "courseId": "3290",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "J80C01 (HH PSYC) D85S01 (AP LING)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "DB 0014"
-            },
-            {
-              "day": "W",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "DB 0014"
-            }
-          ],
-          "instructors": [
-            "Eri Takahashi"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "S2",
       "courseTitle": "Psychology and Law",
-      "courseId": "3310",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "H38W01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH C"
-            },
-            {
-              "day": "W",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH C"
-            }
-          ],
-          "instructors": [
-            "Lillian R Steen"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "S1",
       "courseTitle": "Behaviour in Groups",
-      "courseId": "3430",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "A85X01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "8:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH B"
-            },
-            {
-              "day": "W",
-              "time": "8:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH B"
-            }
-          ],
-          "instructors": [
-            "Peter Papadogiannis"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "S1",
       "courseTitle": "Creativity",
-      "courseId": "3550",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "A42Y01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH B"
-            },
-            {
-              "day": "W",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH B"
-            }
-          ],
-          "instructors": [
-            "Sayyed Mohsen Fatemi"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "S1",
       "courseTitle": "Individual Research Project",
-      "courseId": "3900",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ISTY",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "R32Q01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "Please submit the application form to access enrolment."
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "S2",
       "courseTitle": "Individual Research Project",
-      "courseId": "3901",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ISTY",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "K79C01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "Please submit the application form to access enrolment."
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "SU",
       "courseTitle": "Individual Research Project",
-      "courseId": "3902",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ISTY",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "E26Y01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "Please submit the application form to access enrolment."
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "SU",
       "courseTitle": "Individual Research Project",
-      "courseId": "3903",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ISTY",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "U73T01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "Please submit the application form to access enrolment."
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "S1",
       "courseTitle": "Seminar in Developmental Psychology",
-      "courseId": "4010",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "SEMR",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "V02Y01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S122"
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S122"
-            }
-          ],
-          "instructors": [
-            "Lara Pierce"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "S2",
       "courseTitle": "Seminar in Developmental Psychology",
-      "courseId": "4010",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "Z49U01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Melody Wiseheart"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "SU",
       "courseTitle": "Behaviour Modification and Behaviour Therapy",
-      "courseId": "4030",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "SEMR",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "Z20F01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "8:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S127"
-            },
-            {
-              "day": "R",
-              "time": "8:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S127"
-            }
-          ],
-          "instructors": [
-            "Lorne Sugar"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "S1",
       "courseTitle": "Theoretical Approaches to Counselling and Psychotherapy",
-      "courseId": "4061",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "Z78M01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Jennifer Lewin"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "S2",
       "courseTitle": "Skills and Techniques in Counselling and Psychotherapy",
-      "courseId": "4062",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "SEMR",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "H67Z01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S129"
-            },
-            {
-              "day": "W",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S129"
-            }
-          ],
-          "instructors": [
-            "Jennifer Lewin"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "SU",
       "courseTitle": "Critical Thinking in Psychology",
-      "courseId": "4180",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "SEMR",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "X25V01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH 3009"
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH 3009"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "B",
-          "catalogNumber": "R42E01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "19:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "19:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
+    },
+    {
+      "faculty": "GL",
+      "department": "PSYC",
+      "term": "S1",
+      "courseTitle": "Advanced Seminar",
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "S1",
       "courseTitle": "Individual Research Project",
-      "courseId": "4900",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ISTY",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "E55D01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "Please submit the application form to access enrolment."
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "S2",
       "courseTitle": "Individual Research Project",
-      "courseId": "4901",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ISTY",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "B14A01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "Please submit the application form to access enrolment."
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "SU",
       "courseTitle": "Individual Research Project",
-      "courseId": "4902",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ISTY",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "R61X01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "Please submit the application form to access enrolment."
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "HH",
       "department": "PSYC",
       "term": "SU",
       "courseTitle": "Individual Research Project",
-      "courseId": "4903",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ISTY",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "Y08R01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "Please submit the application form to access enrolment."
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "RLST",
       "term": "SU",
       "courseTitle": "Sikhs and Sikhi(sm): Texts, Contexts, and Living Traditions",
-      "courseId": "1847",
-      "credits": "9.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "TUTR",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "N48M02 (AP HUMA) Z93S02 (AP RLST)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "13:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "13:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "This course will be taught synchronously with the listed days and times."
-        },
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "catalogNumber": "",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:00",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "11:00",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Julie Vig"
-          ],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "02",
-          "catalogNumber": "N48M03 (AP HUMA) Z93S03 (AP RLST)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "13:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "13:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "03",
-          "catalogNumber": "N48M04 (AP HUMA) Z93S04 (AP RLST)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "15:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "15:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "04",
-          "catalogNumber": "N48M05 (AP HUMA) Z93S05 (AP RLST)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "15:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "15:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "05",
-          "catalogNumber": "N48M06 (AP HUMA) Z93S06 (AP RLST)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "17:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "17:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "06",
-          "catalogNumber": "N48M07 (AP HUMA) Z93S07 (AP RLST)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "17:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "17:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "RLST",
       "term": "SU",
       "courseTitle": "Superstition, Religion and Sexuality",
-      "courseId": "3557",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "Y42R01 (AP GWST) S82H01 (AP RLST)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Tanya Taylor"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "RLST",
       "term": "S1",
       "courseTitle": "Bad Girls in the Bible, Part One: Hebrew",
-      "courseId": "3560",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "E89D01 (AP GWST) X88N01 (AP RLST) M29Q01 (GL GWST)",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Tanya Taylor"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "RLST",
       "term": "S2",
       "courseTitle": "Bad Girls in the Bible, Part Two",
-      "courseId": "3561",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "V36Y01 (AP GWST) C35W01 (AP RLST) F76C01 (GL GWST)",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Tanya Taylor"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "RLST",
       "term": "S1",
       "courseTitle": "Torah and Tradition: Jewish Religious Expressions from Antiquity to the Present",
-      "courseId": "3831",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "SEMR",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "D25D01 (AP HUMA) Z64D01 (AP JWST) X11M01 (AP RLST)",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "DB 0015"
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "DB 0015"
-            }
-          ],
-          "instructors": [
-            "Marc Herman"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
+    },
+    {
+      "faculty": "AP",
+      "department": "RLST",
+      "term": "S1",
+      "courseTitle": "Jews and Muslims",
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "RLST",
       "term": "SU",
       "courseTitle": "Faith, Reason, and Modern Self-consciousness in European Thought",
-      "courseId": "4190",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "SEMR",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "P90U01 (AP HUMA) M78J01 (AP RLST)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH 2000"
-            },
-            {
-              "day": "R",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH 2000"
-            }
-          ],
-          "instructors": [
-            "Avron Kulak"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOCI",
       "term": "SU",
       "courseTitle": "Introduction to Sociology",
-      "courseId": "1010",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "BLEN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "F10T01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R N120"
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R N120"
-            }
-          ],
-          "instructors": [
-            "Syed Harris Ali"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOCI",
       "term": "SU",
       "courseTitle": "Sociological Research Methods",
-      "courseId": "2030",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONCA",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "Q78Y01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Glenn J Stalker"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOCI",
       "term": "SU",
       "courseTitle": "Sociological Theory",
-      "courseId": "2040",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "V28M01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S203"
-            },
-            {
-              "day": "R",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S203"
-            }
-          ],
-          "instructors": [
-            "Marcello Musto"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOCI",
       "term": "SU",
       "courseTitle": "Social Interaction and Community",
-      "courseId": "2060",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONCA",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "V57E01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Karen Anderson"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOCI",
       "term": "SU",
       "courseTitle": "Sociology of Aging",
-      "courseId": "3550",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "P04N01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Barbara Gail Hanson"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOCI",
       "term": "S1",
       "courseTitle": "Sociology of Health and Health Care",
-      "courseId": "3820",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "BLEN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "U48G01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S205"
-            },
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S205"
-            },
-            {
-              "day": "W",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S205"
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S205"
-            }
-          ],
-          "instructors": [
-            "Michael Nijhawan"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOCI",
       "term": "S1",
       "courseTitle": "Transnationalism and Diaspora",
-      "courseId": "4390",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "B98X01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S128"
-            },
-            {
-              "day": "W",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S128"
-            }
-          ],
-          "instructors": [
-            "Johanne Jean-Pierre"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOCI",
       "term": "S1",
       "courseTitle": "Racialization and the Law",
-      "courseId": "4440",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "X51W01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S123"
-            },
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S123"
-            },
-            {
-              "day": "W",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S123"
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S123"
-            }
-          ],
-          "instructors": [
-            "Robert A Kenedy"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "GL",
       "department": "SOCI",
       "term": "SU",
       "courseTitle": "Professional Work Placement / Placement en milieu de travail",
-      "courseId": "4975",
-      "credits": "3.00",
-      "languageOfInstruction": "BI",
-      "sections": [
-        {
-          "type": "BLEN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "X83E01",
-          "schedule": [
-            {
-              "day": "F",
-              "time": "13:00",
-              "duration": "110",
-              "campus": "Glendon",
-              "room": "YH A201"
-            }
-          ],
-          "instructors": [
-            "Audrey Pyee"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "SU",
       "courseTitle": "Introduction to Social Science",
-      "courseId": "1000",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "TUTR",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "T48S02",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "catalogNumber": "",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "02",
-          "catalogNumber": "T48S03",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "16:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "03",
-          "catalogNumber": "T48S04",
-          "schedule": [
-            {
-              "day": "R",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "04",
-          "catalogNumber": "T48S05",
-          "schedule": [
-            {
-              "day": "R",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "05",
-          "catalogNumber": "T48S06",
-          "schedule": [
-            {
-              "day": "R",
-              "time": "16:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "06",
-          "catalogNumber": "T48S07",
-          "schedule": [
-            {
-              "day": "W",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "07",
-          "catalogNumber": "T48S08",
-          "schedule": [
-            {
-              "day": "W",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "08",
-          "catalogNumber": "T48S09",
-          "schedule": [
-            {
-              "day": "F",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "09",
-          "catalogNumber": "T48S10",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "10",
-          "catalogNumber": "T48S11",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "16:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "SU",
       "courseTitle": "Self, Culture and Society: Critical Perspectives",
-      "courseId": "1140",
-      "credits": "9.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "TUTR",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "Cancelled",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "catalogNumber": "Cancelled",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "02",
-          "catalogNumber": "Cancelled",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "03",
-          "catalogNumber": "Cancelled",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "04",
-          "catalogNumber": "Cancelled",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "05",
-          "catalogNumber": "Cancelled",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "06",
-          "catalogNumber": "Cancelled",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "07",
-          "catalogNumber": "Cancelled",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "08",
-          "catalogNumber": "Cancelled",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "01",
-          "section": "B",
-          "catalogNumber": "M08J02",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "ONCA",
-          "meetNumber": "01",
-          "catalogNumber": "",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "02",
-          "catalogNumber": "M08J03",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "03",
-          "catalogNumber": "M08J04",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "04",
-          "catalogNumber": "M08J05",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "16:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "16:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "05",
-          "catalogNumber": "M08J06",
-          "schedule": [
-            {
-              "day": "W",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "F",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "06",
-          "catalogNumber": "M08J07",
-          "schedule": [
-            {
-              "day": "W",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "F",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "07",
-          "catalogNumber": "M08J08",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "08",
-          "catalogNumber": "M08J09",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "S1",
       "courseTitle": "Introductory Socio-legal Studies",
-      "courseId": "1375",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "W89V01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "16:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "16:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "GL",
       "department": "SOSC",
       "term": "SU",
       "courseTitle": "Introduction to Linguistics",
-      "courseId": "1603",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "Cancelled",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "SU",
       "courseTitle": "Introduction to Criminology",
-      "courseId": "1650",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "VH D"
-            },
-            {
-              "day": "W",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "VH D"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "01",
-          "catalogNumber": "B42X02 (AP SOSC) R89Q02 (AP CRIM)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "R S103"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "02",
-          "catalogNumber": "B42X03 (AP SOSC) R89Q03 (AP CRIM)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "R S201"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "03",
-          "catalogNumber": "B42X04 (AP SOSC) R89Q04 (AP CRIM)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "R S201"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "04",
-          "catalogNumber": "B42X05 (AP SOSC) R89Q05 (AP CRIM)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "R S127"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "SU",
       "courseTitle": "Justice for Children",
-      "courseId": "1800",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "TUTR",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "D54S02 (AP HREQ) B58V02 (AP SOSC)",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "catalogNumber": "",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "02",
-          "catalogNumber": "D54S03 (AP HREQ) B58V03 (AP SOSC)",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "03",
-          "catalogNumber": "D54S04 (AP HREQ) B58V04 (AP SOSC)",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "12:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "12:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "04",
-          "catalogNumber": "D54S05 (AP HREQ) B58V05 (AP SOSC)",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "12:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "12:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "05",
-          "catalogNumber": "D54S06 (AP HREQ) B58V06 (AP SOSC)",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "06",
-          "catalogNumber": "D54S07 (AP HREQ) B58V07 (AP SOSC)",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "SU",
       "courseTitle": "Human Rights and Equity Issues in Ontario",
-      "courseId": "1940",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "TUTR",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "U01D02 (AP HREQ) S05G02 (AP SOSC)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "13:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "13:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "catalogNumber": "",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "02",
-          "catalogNumber": "U01D03 (AP HREQ) S05G03 (AP SOSC)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "13:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "13:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "03",
-          "catalogNumber": "U01D04 (AP HREQ) S05G04 (AP SOSC)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "16:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "16:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "04",
-          "catalogNumber": "U01D05 (AP HREQ) S05G05 (AP SOSC)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "16:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "16:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "05",
-          "catalogNumber": "U01D06 (AP HREQ) S05G06 (AP SOSC)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "16:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "16:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "06",
-          "catalogNumber": "U01D07 (AP HREQ) S05G07 (AP SOSC)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "17:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "17:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "SU",
       "courseTitle": "Interdisciplinary Approaches to Social Inquiry",
-      "courseId": "2000",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "SEMR",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "A18Z01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R N120"
-            },
-            {
-              "day": "W",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R N120"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "S2",
       "courseTitle": "Graphic Medicine: Narrative Medicine, Graphic Novels and Healing",
-      "courseId": "2112",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "SEMR",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "M95E01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH 3006"
-            },
-            {
-              "day": "W",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH 3006"
-            }
-          ],
-          "instructors": [
-            "Denielle A Elliott"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "SU",
       "courseTitle": "Intermediate Business and Society",
-      "courseId": "2340",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "R S137"
-            },
-            {
-              "day": "W",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "R S137"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "01",
-          "catalogNumber": "D01K02",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "12:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": "R S127"
-            },
-            {
-              "day": "W",
-              "time": "12:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": "R S127"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "02",
-          "catalogNumber": "D01K03",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "13:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": "R S127"
-            },
-            {
-              "day": "W",
-              "time": "13:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": "R S127"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "03",
-          "catalogNumber": "D01K04",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "12:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": "R S174"
-            },
-            {
-              "day": "W",
-              "time": "12:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": "R S174"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "04",
-          "catalogNumber": "D01K05",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "13:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": "R S174"
-            },
-            {
-              "day": "W",
-              "time": "13:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": "R S174"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "SU",
       "courseTitle": "Law and Society",
-      "courseId": "2350",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "SEMR",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "Q36H01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "DB 1016"
-            },
-            {
-              "day": "W",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "DB 1016"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "SU",
       "courseTitle": "Criminal Justice Systems",
-      "courseId": "2652",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "R S137"
-            },
-            {
-              "day": "R",
-              "time": "9:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "R S137"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "01",
-          "catalogNumber": "Y36C02 (AP SOSC) E83Y02 (AP CRIM)",
-          "schedule": [
-            {
-              "day": "R",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "R S174"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "02",
-          "catalogNumber": "Y36C03 (AP SOSC) E83Y03 (AP CRIM)",
-          "schedule": [
-            {
-              "day": "R",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "R S205"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "03",
-          "catalogNumber": "Y36C04 (AP SOSC) E83Y04 (AP CRIM)",
-          "schedule": [
-            {
-              "day": "R",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "FC 109"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "04",
-          "catalogNumber": "Y36C05 (AP SOSC) E83Y05 (AP CRIM)",
-          "schedule": [
-            {
-              "day": "R",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "R N203"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "SU",
       "courseTitle": "Corporate Social Responsibility",
-      "courseId": "3040",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "SEMR",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "T19D01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S103"
-            },
-            {
-              "day": "W",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S103"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "SU",
       "courseTitle": "The Social Economy and Alternative Development",
-      "courseId": "3041",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "SEMR",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "W60G01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S103"
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S103"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "S2",
       "courseTitle": "Business and Social Exclusion in the Global South",
-      "courseId": "3042",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "T77K01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "S1",
       "courseTitle": "Comparative Perspectives on Social Exclusion and Business",
-      "courseId": "3043",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "SEMR",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "N24T01",
-          "schedule": [
-            {
-              "day": "W",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S105"
-            },
-            {
-              "day": "F",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S105"
-            }
-          ],
-          "instructors": [
-            "Sylvia Peacock"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "S1",
       "courseTitle": "Directed Reading",
-      "courseId": "3099",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "DIRD",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "S90Y01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "S2",
       "courseTitle": "Directed Reading",
-      "courseId": "3099",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "DIRD",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "M37U01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "SU",
       "courseTitle": "Directed Reading",
-      "courseId": "3099",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "DIRD",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "F84G01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "S1",
       "courseTitle": "Directed Reading",
-      "courseId": "3099",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "DIRD",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "W31Z01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "S2",
       "courseTitle": "Directed Reading",
-      "courseId": "3099",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "DIRD",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "P78A01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "SU",
       "courseTitle": "Directed Reading",
-      "courseId": "3099",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "DIRD",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "J25J01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "S1",
       "courseTitle": "Selected Topics in Health and Society",
-      "courseId": "3115",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "G71F01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "S2",
       "courseTitle": "Legal Regulation of Migrant Workers: Constructed Insecurity and Worker Resistance",
-      "courseId": "3200",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "SEMR",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "D59R01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "16:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S105"
-            },
-            {
-              "day": "R",
-              "time": "16:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S105"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "S2",
       "courseTitle": "Socio-legal Theories",
-      "courseId": "3375",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "SEMR",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "J83Q01",
-          "schedule": [
-            {
-              "day": "W",
-              "time": "8:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R N120"
-            },
-            {
-              "day": "F",
-              "time": "8:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R N120"
-            }
-          ],
-          "instructors": [
-            "Karrie Sandford"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "S1",
       "courseTitle": "Work in a Warming World: Issues in Work, Labour and Climate Change",
-      "courseId": "3444",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "SEMR",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "Cancelled",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "S2",
       "courseTitle": "Culture, Democracy, and Development in Africa II (Study Abroad)",
-      "courseId": "3483",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "SEMR",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "N53Y01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH 3000"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "SU",
       "courseTitle": "The Global Information Society",
-      "courseId": "3500",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "W57P01 (SC STS ) N50U01 (AP SOSC)",
-          "schedule": [
-            {
-              "day": "W",
-              "time": "16:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S201"
-            }
-          ],
-          "instructors": [
-            "Ian Slater"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "S1",
       "courseTitle": "Technology, Experts and Society",
-      "courseId": "3726",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONCA",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "G10H01 (SC STS ) U03Y01 (AP SOSC)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Angela Cope"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "SU",
       "courseTitle": "Hip Hop and the City",
-      "courseId": "3755",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "J54B01",
-          "schedule": [
-            {
-              "day": "F",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "S1",
       "courseTitle": "Work-Life Balance in a Global Economy",
-      "courseId": "3982",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "SEMR",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "R16R01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "16:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S105"
-            },
-            {
-              "day": "R",
-              "time": "16:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S105"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "S2",
       "courseTitle": "Issues in Business and Society",
-      "courseId": "4040",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "SEMR",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "G42N01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH 1005"
-            },
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH 1005"
-            },
-            {
-              "day": "W",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH 1005"
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH 1005"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "S1",
       "courseTitle": "Business, Communications and Society",
-      "courseId": "4045",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "SEMR",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "M66M01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH 1005"
-            },
-            {
-              "day": "T",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH 1005"
-            },
-            {
-              "day": "W",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH 1005"
-            },
-            {
-              "day": "R",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH 1005"
-            }
-          ],
-          "instructors": [
-            "Sylvia Peacock"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "S1",
       "courseTitle": "Directed Reading",
-      "courseId": "4099",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "DIRD",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "M08F01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "S2",
       "courseTitle": "Directed Reading",
-      "courseId": "4099",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "DIRD",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "F55Z01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "SU",
       "courseTitle": "Directed Reading",
-      "courseId": "4099",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "DIRD",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "W02W01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "S1",
       "courseTitle": "Directed Reading",
-      "courseId": "4099",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "DIRD",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "P49X01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "S2",
       "courseTitle": "Directed Reading",
-      "courseId": "4099",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "DIRD",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "X96R01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "SU",
       "courseTitle": "Directed Reading",
-      "courseId": "4099",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "DIRD",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "C43D01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "GL",
       "department": "SOSC",
       "term": "L2",
       "courseTitle": "Individual Studies",
-      "courseId": "4100",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ISTY",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "J08Z01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "10:00",
-              "duration": "380",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "T",
-              "time": "10:00",
-              "duration": "380",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "10:00",
-              "duration": "380",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "10:00",
-              "duration": "380",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "F",
-              "time": "10:00",
-              "duration": "380",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "L2",
       "courseTitle": "Interdisciplinary Capstone Project",
-      "courseId": "4101",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "SEMR",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "H56P01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "10:00",
-              "duration": "380",
-              "campus": "Keele",
-              "room": "R S104"
-            },
-            {
-              "day": "T",
-              "time": "10:00",
-              "duration": "380",
-              "campus": "Keele",
-              "room": "R S104"
-            },
-            {
-              "day": "W",
-              "time": "10:00",
-              "duration": "380",
-              "campus": "Keele",
-              "room": "R S104"
-            },
-            {
-              "day": "R",
-              "time": "10:00",
-              "duration": "380",
-              "campus": "Keele",
-              "room": "R S104"
-            },
-            {
-              "day": "F",
-              "time": "10:00",
-              "duration": "380",
-              "campus": "Keele",
-              "room": "R S104"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "SU",
       "courseTitle": "Law and Society Honours Seminar",
-      "courseId": "4350",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "D30C01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "SU",
       "courseTitle": "Criminology Honours Seminar",
-      "courseId": "4650",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "SEMR",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "Q65W01 (AP SOSC) K41A01 (AP CRIM)",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH 1154"
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH 1154"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOSC",
       "term": "SU",
       "courseTitle": "Representing Crime",
-      "courseId": "4654",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "SEMR",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "K12X01 (AP SOSC) Q94Z01 (AP CRIM)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH 2009"
-            },
-            {
-              "day": "W",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH 2009"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "GL",
       "department": "SOSC",
       "term": "SU",
       "courseTitle": "Professional Work Placement / Placement en milieu de travail",
-      "courseId": "4975",
-      "credits": "3.00",
-      "languageOfInstruction": "BI",
-      "sections": [
-        {
-          "type": "BLEN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "W98W01 (GL SOSC) N62M01 (GL POLS)",
-          "schedule": [
-            {
-              "day": "F",
-              "time": "13:00",
-              "duration": "110",
-              "campus": "Glendon",
-              "room": "YH A201"
-            }
-          ],
-          "instructors": [
-            "Audrey Pyee"
-          ],
-          "notes": "There will NOT be weekly classes, but some synchronous online or in-person meetings a few times during the session will be required. / Il n'y aura PAS de cours hebdomadaires. Quelques cours en ligne (synchrones) ou en personne seront nécessaires quelques fois pendant la session."
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOWK",
       "term": "S1",
       "courseTitle": "Addiction in Contemporary Society",
-      "courseId": "2020",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "U57C01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Curt Pullan"
-          ],
-          "notes": ""
-        },
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "B",
-          "catalogNumber": "Z04Y01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Curt Pullan"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOWK",
       "term": "S2",
       "courseTitle": "Addiction in Contemporary Society",
-      "courseId": "2020",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "H51U01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Susan Gallagher"
-          ],
-          "notes": ""
-        },
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "N",
-          "catalogNumber": "A98G01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "(Backup)"
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOWK",
       "term": "S1",
       "courseTitle": "Eating Disorders: The Political, Social and Psychological Issues",
-      "courseId": "2025",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "R45Z01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Brenton Diaz"
-          ],
-          "notes": ""
-        },
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "B",
-          "catalogNumber": "K92A01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Brenton Diaz"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOWK",
       "term": "S2",
       "courseTitle": "Eating Disorders: The Political, Social and Psychological Issues",
-      "courseId": "2025",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "E39J01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Brenton Diaz"
-          ],
-          "notes": ""
-        },
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "N",
-          "catalogNumber": "U86R01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "(Backup)"
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOWK",
       "term": "S1",
       "courseTitle": "Current Issues in Mental Health",
-      "courseId": "2035",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONCA",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "Z33D01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Karin E Adlhoch"
-          ],
-          "notes": ""
-        },
-        {
-          "type": "ONCA",
-          "meetNumber": "01",
-          "section": "B",
-          "catalogNumber": "H80M01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOWK",
       "term": "S2",
       "courseTitle": "Current Issues in Mental Health",
-      "courseId": "2035",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONCA",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "B27V01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Karin E Adlhoch"
-          ],
-          "notes": ""
-        },
-        {
-          "type": "ONCA",
-          "meetNumber": "01",
-          "section": "N",
-          "catalogNumber": "R74G01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "(Backup)"
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOWK",
       "term": "S1",
       "courseTitle": "Communication",
-      "courseId": "3041",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "N75T01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "15:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S801"
-            },
-            {
-              "day": "R",
-              "time": "15:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S801"
-            }
-          ],
-          "instructors": [],
-          "notes": "This class will be held at R S801."
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOWK",
       "term": "S2",
       "courseTitle": "Communication",
-      "courseId": "3041",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "H22F01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S801"
-            },
-            {
-              "day": "R",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S801"
-            }
-          ],
-          "instructors": [],
-          "notes": "This class will be held at R S801."
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOWK",
       "term": "SU",
       "courseTitle": "Integrated Social Work Practice",
-      "courseId": "3060",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "A69Z01",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "18:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "ACW 104"
-            },
-            {
-              "day": "R",
-              "time": "18:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "ACW 104"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOWK",
       "term": "S1",
       "courseTitle": "Foundations of Social Work Research",
-      "courseId": "3070",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "E68B01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "ACW 104"
-            },
-            {
-              "day": "W",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "ACW 104"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOWK",
       "term": "S1",
       "courseTitle": "Policy Frameworks",
-      "courseId": "3110",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "R16W01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "15:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "ACW 104"
-            },
-            {
-              "day": "W",
-              "time": "15:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "ACW 104"
-            }
-          ],
-          "instructors": [
-            "Karin E Adlhoch"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOWK",
       "term": "S1",
       "courseTitle": "Social Work with Immigrants and Refugees",
-      "courseId": "4130",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "N48Q01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "HNE 030"
-            },
-            {
-              "day": "R",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "HNE 030"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
+    },
+    {
+      "faculty": "AP",
+      "department": "SOWK",
+      "term": "S2",
+      "courseTitle": "Social Work with Immigrants and Refugees",
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOWK",
       "term": "S1",
       "courseTitle": "Directed Readings/Special Studies",
-      "courseId": "4210",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "DIRD",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "K63X01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOWK",
       "term": "S2",
       "courseTitle": "Directed Readings/Special Studies",
-      "courseId": "4210",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "DIRD",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "E10R01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOWK",
       "term": "S2",
       "courseTitle": "Community Social Work",
-      "courseId": "4220",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "U28K01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOWK",
       "term": "S1",
       "courseTitle": "Poverty, Equality and Social Justice",
-      "courseId": "4350",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "G95C01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "18:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S174"
-            },
-            {
-              "day": "W",
-              "time": "18:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S174"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SOWK",
       "term": "S1",
       "courseTitle": "Addictions",
-      "courseId": "4460",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "Y21P01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "15:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "HNE 032"
-            },
-            {
-              "day": "W",
-              "time": "15:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "HNE 032"
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SP",
       "term": "SU",
       "courseTitle": "Elementary Spanish",
-      "courseId": "1000",
-      "credits": "6.00",
-      "languageOfInstruction": "SE",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "T16M01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Julio Fonseca"
-          ],
-          "notes": "Please complete the online Spanish placement test ."
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "GL",
       "department": "SP",
       "term": "SU",
       "courseTitle": "Spanish Conversation in the Field. A Cultural Immersion Practicum.",
-      "courseId": "2051",
-      "credits": "6.00",
-      "languageOfInstruction": "SP",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "P58J01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Glendon",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Alejandro Zamora"
-          ],
-          "notes": "This course is part of the Summer Abroad Program in University of Mexico (UNAM) at the Taxco campus. Six sessions at YorkU and 12 days abroad. For more information: https://yorkinternational.yorku.ca/gl-sp-2051-spanish-conversation-in-the-field-a-cultural-immersion-practicum/ ."
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "GL",
       "department": "SP",
       "term": "SU",
       "courseTitle": "Community Storytelling across Cultures: Individuals, Communities and their Voices",
-      "courseId": "4608",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "T57T01 (GL SP ) D68S01 (GL COMS)",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Glendon",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Alejandro Zamora"
-          ],
-          "notes": "This course is part of the Summer Abroad Program at Yorks Eco-campus in Costa Rica. It is entirely taught abroad. For more information: https://lasnubes.euc.yorku.ca/education/programs/ ."
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "SP",
       "term": "S2",
       "courseTitle": "Foreign Language and Digital Media: Developing Skills for Online, Spanish-English Publications",
-      "courseId": "4990",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "Q08Q01 (AP SP ) J55C01 (AP HUMA)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "16:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "16:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Maria L Figueredo"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "SC",
       "department": "STS",
       "term": "S1",
       "courseTitle": "Introduction to Science, Technology and Society",
-      "courseId": "1411",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONCA",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "D27Y01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Angela Cope"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "SC",
       "department": "STS",
       "term": "SU",
       "courseTitle": "The Global Information Society",
-      "courseId": "3500",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "LECT",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "W57P01 (SC STS ) N50U01 (AP SOSC)",
-          "schedule": [
-            {
-              "day": "W",
-              "time": "16:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R S201"
-            }
-          ],
-          "instructors": [
-            "Ian Slater"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "SC",
       "department": "STS",
       "term": "S1",
       "courseTitle": "Technology, Experts and Society",
-      "courseId": "3726",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONCA",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "G10H01 (SC STS ) U03Y01 (AP SOSC)",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Angela Cope"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "SC",
       "department": "STS",
       "term": "S1",
       "courseTitle": "Biomedicine and Society",
-      "courseId": "3780",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONCA",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "A15A01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Conor Douglas"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "SC",
       "department": "STS",
       "term": "S1",
       "courseTitle": "Science and Technology Issues in Global Development",
-      "courseId": "3790",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "Q04B01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "SC",
       "department": "STS",
       "term": "SU",
       "courseTitle": "Capstone: Science, Technology and Society Seminar",
-      "courseId": "4501",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "SEMR",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "C98T01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "8:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH 1154"
-            },
-            {
-              "day": "W",
-              "time": "8:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "VH 1154"
-            }
-          ],
-          "instructors": [
-            "James Elwick"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "LE",
       "department": "TECL",
       "term": "SU",
       "courseTitle": "Disruptive Technology Innovation & Entrepreneurship",
-      "courseId": "1000",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "Z53W01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "LE",
       "department": "TECL",
       "term": "S1",
       "courseTitle": "Leadership and Teamwork I",
-      "courseId": "1999",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "FDEX",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "X58P01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Michael R Jenkin"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "LE",
       "department": "TECL",
       "term": "SU",
       "courseTitle": "Innovation, Creativity and Entrepreneurship",
-      "courseId": "2500",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "X00X01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "LE",
       "department": "TECL",
       "term": "SU",
       "courseTitle": "Mechatronics Work-Term I",
-      "courseId": "2910",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "FDEX",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "F46E01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "LE",
       "department": "TECL",
       "term": "S1",
       "courseTitle": "Leadership and Teamwork II",
-      "courseId": "2999",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "FDEX",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "C05B01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Michael R Jenkin"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "LE",
       "department": "TECL",
       "term": "S1",
       "courseTitle": "Leadership and Teamwork III",
-      "courseId": "3999",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "FDEX",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "S52J01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Michael R Jenkin"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "LE",
       "department": "TECL",
       "term": "L2",
       "courseTitle": "Management of Interdisciplinary Projects",
-      "courseId": "4400",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "TUTR",
-          "meetNumber": "01",
-          "section": "Z",
-          "catalogNumber": "",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "9:00",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "M",
-              "time": "16:30",
-              "duration": "20",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "T",
-              "time": "9:00",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "T",
-              "time": "16:30",
-              "duration": "20",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "9:00",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "16:30",
-              "duration": "20",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "9:00",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "16:30",
-              "duration": "20",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "F",
-              "time": "9:00",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "F",
-              "time": "16:30",
-              "duration": "20",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "SEMR",
-          "meetNumber": "01",
-          "catalogNumber": "W09G01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "10:00",
-              "duration": "380",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "T",
-              "time": "10:00",
-              "duration": "380",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "10:00",
-              "duration": "380",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "10:00",
-              "duration": "380",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "F",
-              "time": "10:00",
-              "duration": "380",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "LE",
       "department": "TECL",
       "term": "S1",
       "courseTitle": "Leadership and Teamwork IV",
-      "courseId": "4999",
-      "credits": "0.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "FDEX",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "Y99S01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Michael R Jenkin"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "FA",
       "department": "THEA",
       "term": "S1",
       "courseTitle": "Sex, Drugs, and Theatre",
-      "courseId": "1900",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "TUTR",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "Z36X02",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "catalogNumber": "",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "02",
-          "catalogNumber": "Z36X03",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "03",
-          "catalogNumber": "Z36X04",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "04",
-          "catalogNumber": "Z36X05",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "05",
-          "catalogNumber": "Z36X06",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "06",
-          "catalogNumber": "Z36X07",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "07",
-          "catalogNumber": "Z36X08",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "08",
-          "catalogNumber": "Z36X09",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "09",
-          "catalogNumber": "Z36X10",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "10",
-          "catalogNumber": "Z36X11",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "11",
-          "catalogNumber": "Z36X12",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "12",
-          "catalogNumber": "Z36X13",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "(Backup)"
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "13",
-          "catalogNumber": "Z36X14",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "(Backup)"
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "14",
-          "catalogNumber": "Z36X15",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "(Backup)"
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "FA",
       "department": "THEA",
       "term": "SU",
       "courseTitle": "Independent Production Practicum",
-      "courseId": "2000",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "STDO",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "H83R01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "FA",
       "department": "THEA",
       "term": "SU",
       "courseTitle": "Independent Production Practicum",
-      "courseId": "2000",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "STDO",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "B30D01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "FA",
       "department": "THEA",
       "term": "S2",
       "courseTitle": "Edinburgh Festival Fringe Practicum",
-      "courseId": "2001",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "STDO",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "R77Y01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "FA",
       "department": "THEA",
       "term": "SU",
       "courseTitle": "Independent Production Practicum",
-      "courseId": "3000",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "STDO",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "Y24U01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "FA",
       "department": "THEA",
       "term": "SU",
       "courseTitle": "Independent Production Practicum",
-      "courseId": "3000",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "STDO",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "E71G01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "FA",
       "department": "THEA",
       "term": "S2",
       "courseTitle": "Edinburgh Festival Fringe Practicum",
-      "courseId": "3001",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "STDO",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "V18Z01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "FA",
       "department": "THEA",
       "term": "SU",
       "courseTitle": "Independent Production Practicum",
-      "courseId": "4000",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "STDO",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "X12J01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "FA",
       "department": "THEA",
       "term": "SU",
       "courseTitle": "Independent Production Practicum",
-      "courseId": "4000",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "STDO",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "B59S01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "FA",
       "department": "THEA",
       "term": "S2",
       "courseTitle": "Edinburgh Festival Fringe Practicum",
-      "courseId": "4001",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "STDO",
-          "meetNumber": "01",
-          "section": "M",
-          "catalogNumber": "S06D01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "FA",
       "department": "THEA",
       "term": "SU",
       "courseTitle": "Independent Study I",
-      "courseId": "4300",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ISTY",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "Z65A01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "FA",
       "department": "THEA",
       "term": "SU",
       "courseTitle": "Independent Study I",
-      "courseId": "4300",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ISTY",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "Y53M01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "FA",
       "department": "THEA",
       "term": "SU",
       "courseTitle": "Independent Study II",
-      "courseId": "4301",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ISTY",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "F00V01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Courtney Ch'ng Lancaster"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "FA",
       "department": "THEA",
       "term": "SU",
       "courseTitle": "Independent Study II",
-      "courseId": "4301",
-      "credits": "6.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ISTY",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "V47G01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
+    },
+    {
+      "faculty": "FA",
+      "department": "THEA",
+      "term": "S1",
+      "courseTitle": "Improvisation and Playmaking",
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "GL",
       "department": "TRAN",
       "term": "SU",
       "courseTitle": "Onsite Professional Internship/Stage professionnel en entreprise",
-      "courseId": "3900",
-      "credits": "3.00",
-      "languageOfInstruction": "BI",
-      "sections": [
-        {
-          "type": "PRAC",
-          "meetNumber": "01",
-          "section": "B",
-          "catalogNumber": "F35A01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Glendon",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Audrey Pyee"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "GL",
       "department": "TRAN",
       "term": "S1",
       "courseTitle": "Texts and beyond: Adapting books, ads, films, and video games",
-      "courseId": "4605",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "C59F01 (GL TRAN) T06N01 (GL COMS)",
-          "schedule": [
-            {
-              "day": "",
-              "time": "",
-              "duration": "0",
-              "campus": "Glendon",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "This course will be offered through remote/online delivery and is an asynchronous course with no specified meeting times. Additional information will be provided by your course instructor (by email or eClass)."
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "GL",
@@ -45108,1051 +37386,60 @@
       "department": "TRAN",
       "term": "SU",
       "courseTitle": "Online Professional Internship/Stage professionnel à distance",
-      "courseId": "4900",
-      "credits": "3.00",
-      "languageOfInstruction": "BI",
-      "sections": [
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "section": "B",
-          "catalogNumber": "V82X01",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Glendon",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Audrey Pyee"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "FA",
       "department": "VISA",
       "term": "S1",
       "courseTitle": "The Photographic Experience",
-      "courseId": "1006",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "TUTR",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "C15X02",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "8:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "8:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "catalogNumber": "",
-          "schedule": [
-            {
-              "day": "",
-              "time": "0:00",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Robyn Cumming"
-          ],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "02",
-          "catalogNumber": "C15X03",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "9:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "9:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "03",
-          "catalogNumber": "C15X04",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "10:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "10:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "04",
-          "catalogNumber": "C15X05",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "05",
-          "catalogNumber": "C15X06",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "12:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "12:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "06",
-          "catalogNumber": "C15X07",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "13:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "13:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "07",
-          "catalogNumber": "C15X08",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "12:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "12:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "08",
-          "catalogNumber": "C15X09",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "13:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "13:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "09",
-          "catalogNumber": "C15X10",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "8:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "8:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "10",
-          "catalogNumber": "C15X11",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "9:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "9:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "11",
-          "catalogNumber": "C15X12",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "10:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "10:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "12",
-          "catalogNumber": "C15X13",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "11:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "13",
-          "catalogNumber": "C15X14",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "12:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "12:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "14",
-          "catalogNumber": "C15X15",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "13:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "13:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "15",
-          "catalogNumber": "C15X16",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "9:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "9:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "16",
-          "catalogNumber": "C15X17",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "10:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "10:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "17",
-          "catalogNumber": "C15X18",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "14:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "14:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "18",
-          "catalogNumber": "C15X19",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "15:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "15:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "19",
-          "catalogNumber": "C15X20",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "16:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "16:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "20",
-          "catalogNumber": "C15X21",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "17:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "17:30",
-              "duration": "50",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "FA",
       "department": "VISA",
       "term": "S1",
       "courseTitle": "Drawing: Perception, Proportion, Structure",
-      "courseId": "2081",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "BLEN",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "",
-          "schedule": [
-            {
-              "day": "",
-              "time": "",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Joy Wong"
-          ],
-          "notes": ""
-        },
-        {
-          "type": "LAB",
-          "meetNumber": "01",
-          "catalogNumber": "R50J02",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "10:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "CFA 284"
-            },
-            {
-              "day": "W",
-              "time": "10:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": "CFA 284"
-            }
-          ],
-          "instructors": [
-            "Joy Wong"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "FA",
       "department": "VISA",
       "term": "I1",
       "courseTitle": "Intensive Sculpture Workshop",
-      "courseId": "3090Z",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "STDO",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "X68W01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "9:30",
-              "duration": "220",
-              "campus": "Keele",
-              "room": "CFA 004"
-            },
-            {
-              "day": "T",
-              "time": "9:30",
-              "duration": "220",
-              "campus": "Keele",
-              "room": "CFA 004"
-            },
-            {
-              "day": "W",
-              "time": "9:30",
-              "duration": "220",
-              "campus": "Keele",
-              "room": "CFA 004"
-            }
-          ],
-          "instructors": [
-            "Holly Ward"
-          ],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "WRIT",
       "term": "SU",
       "courseTitle": "Writing: Process and Practice",
-      "courseId": "1700",
-      "credits": "9.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "TUTR",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "W98X02 (AP WRIT) V89K02 (AP HUMA) X83F02 (AP EN )",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "catalogNumber": "",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "10:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "10:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [
-            "Jon J Sufrin"
-          ],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "02",
-          "catalogNumber": "W98X03 (AP WRIT) V89K03 (AP HUMA) X83F03 (AP EN )",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "03",
-          "catalogNumber": "W98X04 (AP WRIT) V89K04 (AP HUMA) X83F04 (AP EN )",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "12:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "04",
-          "catalogNumber": "W98X05 (AP WRIT) V89K05 (AP HUMA) X83F05 (AP EN )",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "05",
-          "catalogNumber": "W98X06 (AP WRIT) V89K06 (AP HUMA) X83F06 (AP EN )",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "06",
-          "catalogNumber": "W98X07 (AP WRIT) V89K07 (AP HUMA) X83F07 (AP EN )",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "14:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "07",
-          "catalogNumber": "W98X08 (AP WRIT) V89K08 (AP HUMA) X83F08 (AP EN )",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "08",
-          "catalogNumber": "W98X09 (AP WRIT) V89K09 (AP HUMA) X83F09 (AP EN )",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "09",
-          "catalogNumber": "W98X10 (AP WRIT) V89K10 (AP HUMA) X83F10 (AP EN )",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "(Backup)"
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "10",
-          "catalogNumber": "W98X11 (AP WRIT) V89K11 (AP HUMA) X83F11 (AP EN )",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "11:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "11:30",
-              "duration": "110",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": "(Backup)"
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "01",
-          "section": "B",
-          "catalogNumber": "Cancelled",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "catalogNumber": "Cancelled",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "02",
-          "catalogNumber": "Cancelled",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "03",
-          "catalogNumber": "Cancelled",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "04",
-          "catalogNumber": "Cancelled",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "05",
-          "catalogNumber": "Cancelled",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "06",
-          "catalogNumber": "Cancelled",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "07",
-          "catalogNumber": "Cancelled",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "08",
-          "catalogNumber": "Cancelled",
-          "schedule": [],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "09",
-          "catalogNumber": "Cancelled",
-          "schedule": [],
-          "instructors": [],
-          "notes": "(Backup)"
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "10",
-          "catalogNumber": "Cancelled",
-          "schedule": [],
-          "instructors": [],
-          "notes": "(Backup)"
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     },
     {
       "faculty": "AP",
       "department": "WRIT",
       "term": "S1",
       "courseTitle": "Effective Writing and Research in Information Technology",
-      "courseId": "2201",
-      "credits": "3.00",
-      "languageOfInstruction": "EN",
-      "sections": [
-        {
-          "type": "TUTR",
-          "meetNumber": "01",
-          "section": "A",
-          "catalogNumber": "B03B02",
-          "schedule": [
-            {
-              "day": "",
-              "time": "",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "ONLN",
-          "meetNumber": "01",
-          "catalogNumber": "",
-          "schedule": [
-            {
-              "day": "",
-              "time": "",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "02",
-          "catalogNumber": "B03B03",
-          "schedule": [
-            {
-              "day": "",
-              "time": "",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        },
-        {
-          "type": "TUTR",
-          "meetNumber": "03",
-          "catalogNumber": "B03B04",
-          "schedule": [
-            {
-              "day": "",
-              "time": "",
-              "duration": "0",
-              "campus": "Keele",
-              "room": ""
-            }
-          ],
-          "instructors": [],
-          "notes": ""
-        }
-      ]
+      "courseId": "",
+      "credits": "",
+      "languageOfInstruction": "",
+      "sections": []
     }
   ]
 }

--- a/scraping/data/summer-2026/graduate_studies.json
+++ b/scraping/data/summer-2026/graduate_studies.json
@@ -1579,6 +1579,62 @@
     {
       "faculty": "GS",
       "department": "CIVL",
+      "term": "SU",
+      "courseTitle": "Bridge Engineering",
+      "courseId": "6414",
+      "credits": "3.00",
+      "languageOfInstruction": "EN",
+      "sections": [
+        {
+          "type": "SEMR",
+          "meetNumber": "01",
+          "section": "A",
+          "catalogNumber": "Q68X01",
+          "schedule": [
+            {
+              "day": "T",
+              "time": "10:00",
+              "duration": "170",
+              "campus": "Keele",
+              "room": "BC 214"
+            }
+          ],
+          "instructors": [],
+          "notes": ""
+        }
+      ]
+    },
+    {
+      "faculty": "GS",
+      "department": "CIVL",
+      "term": "S1",
+      "courseTitle": "Directed Reading in Transportation Engineering",
+      "courseId": "6500",
+      "credits": "3.00",
+      "languageOfInstruction": "EN",
+      "sections": [
+        {
+          "type": "SEMR",
+          "meetNumber": "01",
+          "section": "A",
+          "catalogNumber": "Z43T01",
+          "schedule": [
+            {
+              "day": "W",
+              "time": "13:00",
+              "duration": "170",
+              "campus": "Keele",
+              "room": ""
+            }
+          ],
+          "instructors": [],
+          "notes": "In BRG 345-1 (Department Meeting Room)"
+        }
+      ]
+    },
+    {
+      "faculty": "GS",
+      "department": "CIVL",
       "term": "S1",
       "courseTitle": "Computational Methods in Hydrodynamics",
       "courseId": "6610",
@@ -1599,8 +1655,38 @@
               "room": "BRG 213"
             }
           ],
-          "instructors": [],
+          "instructors": [
+            "Shooka Karimpour"
+          ],
           "notes": ""
+        }
+      ]
+    },
+    {
+      "faculty": "GS",
+      "department": "CIVL",
+      "term": "S2",
+      "courseTitle": "Data-driven modelling and uncertainty analysis for water resources engineering",
+      "courseId": "6620",
+      "credits": "3.00",
+      "languageOfInstruction": "EN",
+      "sections": [
+        {
+          "type": "SEMR",
+          "meetNumber": "01",
+          "section": "M",
+          "catalogNumber": "X19U01",
+          "schedule": [
+            {
+              "day": "T",
+              "time": "11:00",
+              "duration": "170",
+              "campus": "Keele",
+              "room": ""
+            }
+          ],
+          "instructors": [],
+          "notes": "In BRG 345-1 (Department Meeting Room)"
         }
       ]
     },
@@ -2141,7 +2227,9 @@
               "room": ""
             }
           ],
-          "instructors": [],
+          "instructors": [
+            "Nirupama Agrawal"
+          ],
           "notes": ""
         }
       ]
@@ -2528,14 +2616,14 @@
           "schedule": [
             {
               "day": "T",
-              "time": "14:30",
+              "time": "17:30",
               "duration": "170",
               "campus": "Keele",
               "room": ""
             },
             {
               "day": "R",
-              "time": "14:30",
+              "time": "17:30",
               "duration": "170",
               "campus": "Keele",
               "room": ""
@@ -2845,6 +2933,41 @@
           ],
           "instructors": [],
           "notes": "This is a non-credit course that graduate students must enrol into for every term they are working on either a MEd Major Research Project (MRP), MEd Thesis or PhD Doctoral Dissertation. Self-directed work on a MEd Major Research Project (MRP), MEd Thesis or PhD Doctoral Dissertation with their supervisor.Â"
+        }
+      ]
+    },
+    {
+      "faculty": "GS",
+      "department": "EECS",
+      "term": "S1",
+      "courseTitle": "Information Networks",
+      "courseId": "5414",
+      "credits": "3.00",
+      "languageOfInstruction": "EN",
+      "sections": [
+        {
+          "type": "LECT",
+          "meetNumber": "01",
+          "section": "A",
+          "catalogNumber": "B22X01",
+          "schedule": [
+            {
+              "day": "T",
+              "time": "11:00",
+              "duration": "170",
+              "campus": "Keele",
+              "room": "HNE B15"
+            },
+            {
+              "day": "W",
+              "time": "13:00",
+              "duration": "170",
+              "campus": "Keele",
+              "room": "HNE B15"
+            }
+          ],
+          "instructors": [],
+          "notes": ""
         }
       ]
     },
@@ -3172,7 +3295,7 @@
           "instructors": [
             "Gail Fraser"
           ],
-          "notes": ""
+          "notes": "The course is offer as a field/workshop style. There are at least two days where the class will be meeting off campus in the Toronto area and students will be expected to make their own way to these protected area locations. For many sessions you will be outdoors, and a significant amount of walking may be needed. It is expected that students in this course will have some knowledge of introductory ecology."
         }
       ]
     },
@@ -3223,7 +3346,7 @@
           "instructors": [
             "Jin Haritaworn"
           ],
-          "notes": ""
+          "notes": "This course is meeting May 4-19 inclusive. See course syllabus for more details."
         }
       ]
     },
@@ -3309,6 +3432,55 @@
           "instructors": [
             "Peter Timmerman"
           ],
+          "notes": "This course is meeting June 16-29 inclusive. See course syllabus for more details."
+        }
+      ]
+    },
+    {
+      "faculty": "GS",
+      "department": "ENVS",
+      "term": "I2",
+      "courseTitle": "International Political Economy and Ecology Summer School",
+      "courseId": "6275",
+      "credits": "3.00",
+      "languageOfInstruction": "EN",
+      "sections": [
+        {
+          "type": "SEMR",
+          "meetNumber": "01",
+          "section": "A",
+          "catalogNumber": "B82J01 (GS ENVS) X35A01 (GS GEOG) Z88Z01 (GS POLS)",
+          "schedule": [
+            {
+              "day": "M",
+              "time": "9:00",
+              "duration": "350",
+              "campus": "Keele",
+              "room": "HNE 140"
+            },
+            {
+              "day": "T",
+              "time": "9:00",
+              "duration": "350",
+              "campus": "Keele",
+              "room": ""
+            },
+            {
+              "day": "W",
+              "time": "9:00",
+              "duration": "350",
+              "campus": "Keele",
+              "room": ""
+            },
+            {
+              "day": "R",
+              "time": "9:00",
+              "duration": "350",
+              "campus": "Keele",
+              "room": ""
+            }
+          ],
+          "instructors": [],
           "notes": ""
         }
       ]
@@ -3357,8 +3529,10 @@
               "room": "HNE 140"
             }
           ],
-          "instructors": [],
-          "notes": ""
+          "instructors": [
+            "Loren March"
+          ],
+          "notes": "This course is meeting May 11-26 inclusive. See course syllabus for more details."
         }
       ]
     },
@@ -3617,7 +3791,7 @@
             }
           ],
           "instructors": [],
-          "notes": ""
+          "notes": "This offering is part of the Cross-Campus Capstone Classroom (C4) Management program. From June 1 to June 12 (with Capstone Day on June 19), students will work in interdisciplinary teams on a project sprint focused on real-world social impact. To apply, visit https://www.yorku.ca/c4/apply-for-c4/ ."
         },
         {
           "type": "FDEX",
@@ -5018,6 +5192,55 @@
     {
       "faculty": "GS",
       "department": "GEOG",
+      "term": "I2",
+      "courseTitle": "International Political Economy and Ecology Summer School",
+      "courseId": "5395",
+      "credits": "3.00",
+      "languageOfInstruction": "EN",
+      "sections": [
+        {
+          "type": "SEMR",
+          "meetNumber": "01",
+          "section": "A",
+          "catalogNumber": "B82J01 (GS ENVS) X35A01 (GS GEOG) Z88Z01 (GS POLS)",
+          "schedule": [
+            {
+              "day": "M",
+              "time": "9:00",
+              "duration": "350",
+              "campus": "Keele",
+              "room": "HNE 140"
+            },
+            {
+              "day": "T",
+              "time": "9:00",
+              "duration": "350",
+              "campus": "Keele",
+              "room": ""
+            },
+            {
+              "day": "W",
+              "time": "9:00",
+              "duration": "350",
+              "campus": "Keele",
+              "room": ""
+            },
+            {
+              "day": "R",
+              "time": "9:00",
+              "duration": "350",
+              "campus": "Keele",
+              "room": ""
+            }
+          ],
+          "instructors": [],
+          "notes": ""
+        }
+      ]
+    },
+    {
+      "faculty": "GS",
+      "department": "GEOG",
       "term": "SU",
       "courseTitle": "M.A./M.Sc. Research Paper",
       "courseId": "6010",
@@ -5202,7 +5425,7 @@
           "instructors": [
             "Jin Haritaworn"
           ],
-          "notes": ""
+          "notes": "This course is meeting May 4-19 inclusive. See course syllabus for more details."
         }
       ]
     },
@@ -6896,7 +7119,9 @@
               "room": ""
             }
           ],
-          "instructors": [],
+          "instructors": [
+            "Eva Hava Peisachovich"
+          ],
           "notes": ""
         }
       ]
@@ -7056,7 +7281,7 @@
               "time": "9:00",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "HNE B26"
             }
           ],
           "instructors": [
@@ -7075,7 +7300,7 @@
               "time": "13:00",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "HNE B26"
             }
           ],
           "instructors": [
@@ -7094,7 +7319,7 @@
               "time": "9:00",
               "duration": "170",
               "campus": "Keele",
-              "room": ""
+              "room": "HNE B26"
             }
           ],
           "instructors": [
@@ -7792,7 +8017,9 @@
               "room": "DB 1004"
             }
           ],
-          "instructors": [],
+          "instructors": [
+            "Romi-Lee Sevel"
+          ],
           "notes": ""
         },
         {
@@ -7809,7 +8036,9 @@
               "room": "DB 0007"
             }
           ],
-          "instructors": [],
+          "instructors": [
+            "Romi-Lee Sevel"
+          ],
           "notes": ""
         }
       ]
@@ -7830,11 +8059,11 @@
           "catalogNumber": "J02W01",
           "schedule": [
             {
-              "day": "R",
-              "time": "11:00",
+              "day": "T",
+              "time": "18:30",
               "duration": "170",
               "campus": "Keele",
-              "room": "CLH M"
+              "room": "DB 0005"
             }
           ],
           "instructors": [],
@@ -7882,7 +8111,9 @@
               "room": "DB 1004"
             }
           ],
-          "instructors": [],
+          "instructors": [
+            "Joanne E Magee"
+          ],
           "notes": ""
         },
         {
@@ -7899,7 +8130,9 @@
               "room": "DB 1004"
             }
           ],
-          "instructors": [],
+          "instructors": [
+            "Joanne E Magee"
+          ],
           "notes": ""
         }
       ]
@@ -7948,11 +8181,11 @@
           "catalogNumber": "F90Y01",
           "schedule": [
             {
-              "day": "M",
-              "time": "11:30",
+              "day": "R",
+              "time": "14:30",
               "duration": "170",
               "campus": "Keele",
-              "room": "R S105"
+              "room": "DB 0001"
             }
           ],
           "instructors": [],
@@ -8429,6 +8662,55 @@
           "instructors": [
             "Nikita Blinov"
           ],
+          "notes": ""
+        }
+      ]
+    },
+    {
+      "faculty": "GS",
+      "department": "POLS",
+      "term": "I2",
+      "courseTitle": "International Political Economy and Ecology Summer School",
+      "courseId": "6282",
+      "credits": "3.00",
+      "languageOfInstruction": "EN",
+      "sections": [
+        {
+          "type": "SEMR",
+          "meetNumber": "01",
+          "section": "A",
+          "catalogNumber": "B82J01 (GS ENVS) X35A01 (GS GEOG) Z88Z01 (GS POLS)",
+          "schedule": [
+            {
+              "day": "M",
+              "time": "9:00",
+              "duration": "350",
+              "campus": "Keele",
+              "room": "HNE 140"
+            },
+            {
+              "day": "T",
+              "time": "9:00",
+              "duration": "350",
+              "campus": "Keele",
+              "room": ""
+            },
+            {
+              "day": "W",
+              "time": "9:00",
+              "duration": "350",
+              "campus": "Keele",
+              "room": ""
+            },
+            {
+              "day": "R",
+              "time": "9:00",
+              "duration": "350",
+              "campus": "Keele",
+              "room": ""
+            }
+          ],
+          "instructors": [],
           "notes": ""
         }
       ]
@@ -9276,26 +9558,9 @@
           "type": "SEMR",
           "meetNumber": "01",
           "section": "A",
-          "catalogNumber": "H49H01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R N814"
-            },
-            {
-              "day": "W",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "R N814"
-            }
-          ],
-          "instructors": [
-            "Maggie E Toplak"
-          ],
+          "catalogNumber": "Cancelled",
+          "schedule": [],
+          "instructors": [],
           "notes": ""
         }
       ]
@@ -9453,7 +9718,9 @@
               "room": "R N836"
             }
           ],
-          "instructors": [],
+          "instructors": [
+            "Kinnon Ross MacKinnon"
+          ],
           "notes": ""
         }
       ]

--- a/scraping/data/summer-2026/schulich.json
+++ b/scraping/data/summer-2026/schulich.json
@@ -180,39 +180,16 @@
           "type": "LECT",
           "meetNumber": "01",
           "section": "M",
-          "catalogNumber": "",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "13:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "SSB E118"
-            },
-            {
-              "day": "W",
-              "time": "13:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "SSB E118"
-            }
-          ],
+          "catalogNumber": "Cancelled",
+          "schedule": [],
           "instructors": [],
           "notes": ""
         },
         {
           "type": "LAB",
           "meetNumber": "01",
-          "catalogNumber": "R45T02",
-          "schedule": [
-            {
-              "day": "W",
-              "time": "17:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "SSB E112"
-            }
-          ],
+          "catalogNumber": "Cancelled",
+          "schedule": [],
           "instructors": [],
           "notes": ""
         },
@@ -327,39 +304,16 @@
           "type": "LECT",
           "meetNumber": "01",
           "section": "M",
-          "catalogNumber": "",
-          "schedule": [
-            {
-              "day": "T",
-              "time": "13:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "SSB N106"
-            },
-            {
-              "day": "R",
-              "time": "13:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "SSB N106"
-            }
-          ],
+          "catalogNumber": "Cancelled",
+          "schedule": [],
           "instructors": [],
           "notes": ""
         },
         {
           "type": "LAB",
           "meetNumber": "01",
-          "catalogNumber": "E39Z02",
-          "schedule": [
-            {
-              "day": "R",
-              "time": "17:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "SSB E111"
-            }
-          ],
+          "catalogNumber": "Cancelled",
+          "schedule": [],
           "instructors": [],
           "notes": ""
         },
@@ -394,7 +348,7 @@
           "schedule": [
             {
               "day": "R",
-              "time": "10:00",
+              "time": "13:00",
               "duration": "170",
               "campus": "Keele",
               "room": "SSB E111"
@@ -418,39 +372,16 @@
           "type": "LECT",
           "meetNumber": "01",
           "section": "M",
-          "catalogNumber": "",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "13:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "SSB E115"
-            },
-            {
-              "day": "W",
-              "time": "13:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "SSB E115"
-            }
-          ],
+          "catalogNumber": "Cancelled",
+          "schedule": [],
           "instructors": [],
           "notes": ""
         },
         {
           "type": "LAB",
           "meetNumber": "01",
-          "catalogNumber": "U57H02",
-          "schedule": [
-            {
-              "day": "W",
-              "time": "17:00",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "SSB E112"
-            }
-          ],
+          "catalogNumber": "Cancelled",
+          "schedule": [],
           "instructors": [],
           "notes": ""
         },
@@ -1647,6 +1578,62 @@
     {
       "faculty": "SB",
       "department": "ENTR",
+      "term": "K",
+      "courseTitle": "Designing Startup Communities: Inside Toronto's Innovation Ecosystem",
+      "courseId": "6630",
+      "credits": "3.00",
+      "languageOfInstruction": "EN",
+      "sections": [
+        {
+          "type": "LECT",
+          "meetNumber": "01",
+          "section": "M",
+          "catalogNumber": "E15Y01",
+          "schedule": [
+            {
+              "day": "M",
+              "time": "9:00",
+              "duration": "470",
+              "campus": "Off Campus",
+              "room": ""
+            },
+            {
+              "day": "T",
+              "time": "9:00",
+              "duration": "470",
+              "campus": "Off Campus",
+              "room": ""
+            },
+            {
+              "day": "W",
+              "time": "9:00",
+              "duration": "470",
+              "campus": "Off Campus",
+              "room": ""
+            },
+            {
+              "day": "R",
+              "time": "9:00",
+              "duration": "470",
+              "campus": "Off Campus",
+              "room": ""
+            },
+            {
+              "day": "F",
+              "time": "9:00",
+              "duration": "470",
+              "campus": "Off Campus",
+              "room": ""
+            }
+          ],
+          "instructors": [],
+          "notes": ""
+        }
+      ]
+    },
+    {
+      "faculty": "SB",
+      "department": "ENTR",
       "term": "E",
       "courseTitle": "Individual Study: Selected Problems in Entrepreneurial Studies",
       "courseId": "6900",
@@ -1713,44 +1700,8 @@
           "type": "LECT",
           "meetNumber": "01",
           "section": "M",
-          "catalogNumber": "V73V01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "9:00",
-              "duration": "470",
-              "campus": "Off Campus",
-              "room": ""
-            },
-            {
-              "day": "T",
-              "time": "9:00",
-              "duration": "470",
-              "campus": "Off Campus",
-              "room": ""
-            },
-            {
-              "day": "W",
-              "time": "9:00",
-              "duration": "470",
-              "campus": "Off Campus",
-              "room": ""
-            },
-            {
-              "day": "R",
-              "time": "9:00",
-              "duration": "470",
-              "campus": "Off Campus",
-              "room": ""
-            },
-            {
-              "day": "F",
-              "time": "9:00",
-              "duration": "470",
-              "campus": "Off Campus",
-              "room": ""
-            }
-          ],
+          "catalogNumber": "Cancelled",
+          "schedule": [],
           "instructors": [],
           "notes": ""
         }
@@ -2420,7 +2371,7 @@
               "time": "19:00",
               "duration": "170",
               "campus": "Keele",
-              "room": "SSB W136"
+              "room": "SSB S236"
             }
           ],
           "instructors": [],
@@ -2448,7 +2399,7 @@
               "time": "14:30",
               "duration": "170",
               "campus": "Keele",
-              "room": "SSB W136"
+              "room": "SSB S236"
             }
           ],
           "instructors": [],
@@ -2476,7 +2427,7 @@
               "time": "14:30",
               "duration": "170",
               "campus": "Keele",
-              "room": "SSB N105"
+              "room": "SSB S236"
             }
           ],
           "instructors": [],
@@ -2560,7 +2511,7 @@
               "time": "18:30",
               "duration": "170",
               "campus": "Keele",
-              "room": "SSB E115"
+              "room": "SSB S236"
             }
           ],
           "instructors": [],
@@ -2588,7 +2539,7 @@
               "time": "19:00",
               "duration": "170",
               "campus": "Keele",
-              "room": "SSB S124"
+              "room": "SSB S236"
             }
           ],
           "instructors": [],
@@ -2829,7 +2780,7 @@
               "time": "18:30",
               "duration": "170",
               "campus": "Keele",
-              "room": "SSB E115"
+              "room": "SSB S236"
             }
           ],
           "instructors": [],
@@ -2857,7 +2808,7 @@
               "time": "14:30",
               "duration": "170",
               "campus": "Keele",
-              "room": "SSB W133"
+              "room": "SSB S236"
             }
           ],
           "instructors": [],
@@ -2885,7 +2836,7 @@
               "time": "19:00",
               "duration": "170",
               "campus": "Keele",
-              "room": "SSB E115"
+              "room": "SSB S236"
             }
           ],
           "instructors": [],
@@ -3596,6 +3547,26 @@
       "faculty": "SB",
       "department": "MKTG",
       "term": "S",
+      "courseTitle": "Service Marketing",
+      "courseId": "6300",
+      "credits": "3.00",
+      "languageOfInstruction": "EN",
+      "sections": [
+        {
+          "type": "LECT",
+          "meetNumber": "01",
+          "section": "S",
+          "catalogNumber": "Cancelled",
+          "schedule": [],
+          "instructors": [],
+          "notes": ""
+        }
+      ]
+    },
+    {
+      "faculty": "SB",
+      "department": "MKTG",
+      "term": "S",
       "courseTitle": "Strategic Professional Selling",
       "courseId": "6570",
       "credits": "3.00",
@@ -3936,14 +3907,23 @@
           "type": "LECT",
           "meetNumber": "01",
           "section": "M",
-          "catalogNumber": "N17R01",
+          "catalogNumber": "Cancelled",
+          "schedule": [],
+          "instructors": [],
+          "notes": ""
+        },
+        {
+          "type": "LECT",
+          "meetNumber": "01",
+          "section": "S",
+          "catalogNumber": "X57W01",
           "schedule": [
             {
-              "day": "T",
-              "time": "10:00",
+              "day": "M",
+              "time": "19:00",
               "duration": "170",
               "campus": "Keele",
-              "room": "SSB W133"
+              "room": "SSB W136"
             }
           ],
           "instructors": [],
@@ -4302,16 +4282,8 @@
           "type": "LECT",
           "meetNumber": "01",
           "section": "M",
-          "catalogNumber": "U06Q01",
-          "schedule": [
-            {
-              "day": "M",
-              "time": "14:30",
-              "duration": "170",
-              "campus": "Keele",
-              "room": "SSB E112"
-            }
-          ],
+          "catalogNumber": "Cancelled",
+          "schedule": [],
           "instructors": [],
           "notes": ""
         },
@@ -4322,11 +4294,11 @@
           "catalogNumber": "N53C01",
           "schedule": [
             {
-              "day": "M",
+              "day": "T",
               "time": "19:00",
               "duration": "170",
               "campus": "Keele",
-              "room": "SSB E112"
+              "room": "SSB E111"
             }
           ],
           "instructors": [],

--- a/scraping/scrapers/helpers/course_parsing.py
+++ b/scraping/scrapers/helpers/course_parsing.py
@@ -84,8 +84,43 @@ def parse_schedule_entry(schedule_cells: List[Tag]) -> Dict[str, str]:
     }
 
 
+def extract_from_schedule_cell(schedule_cell: Tag) -> tuple[List[str], str]:
+    """Extract instructors and notes from nested TDs inside the schedule cell (old HTML structure)."""
+    instructors: List[str] = []
+    notes = ""
+    
+    nested_tds = schedule_cell.find_all("td", recursive=False)
+    if len(nested_tds) >= 1:
+        instructors = parse_instructors(nested_tds[0].decode_contents())
+    if len(nested_tds) >= 2:
+        notes = parse_notes(nested_tds[1].decode_contents())
+    
+    return instructors, notes
+
+
+def extract_from_sibling_cells(row_cells: List[Tag], section_type_index: int) -> tuple[List[str], str]:
+    """Extract instructors and notes from sibling TD cells at offsets 4 and 5 (new HTML structure)."""
+    instructors: List[str] = []
+    notes = ""
+    
+    # Instructors are at offset +4 from section_type_index
+    if len(row_cells) > section_type_index + 4:
+        instructors = parse_instructors(row_cells[section_type_index + 4].decode_contents())
+    
+    # Notes are at offset +5 from section_type_index
+    if len(row_cells) > section_type_index + 5:
+        notes = parse_notes(row_cells[section_type_index + 5].decode_contents())
+    
+    return instructors, notes
+
+
 def build_details(row_cells: List[Tag], section_type_index: int) -> tuple[List[Dict[str, str]], List[str], str, str, bool]:
-    """Construct schedule, instructors, notes, catalog_number and is_cancelled for a section row."""
+    """Construct schedule, instructors, notes, catalog_number and is_cancelled for a section row.
+    
+    Supports both old and new HTML structures:
+    - Old: instructors/notes nested inside schedule cell
+    - New: instructors/notes as sibling cells at offsets +4 and +5
+    """
     schedule: List[Dict[str, str]] = []
     catalog_cell = row_cells[section_type_index + 2] if len(row_cells) > section_type_index + 2 else None
     schedule_cell = row_cells[section_type_index + 3] if len(row_cells) > section_type_index + 3 else None
@@ -109,11 +144,12 @@ def build_details(row_cells: List[Tag], section_type_index: int) -> tuple[List[D
             if schedule_text and schedule_text.lower() != "cancelled":
                 schedule.append({"day": "", "time": schedule_text, "duration": "", "campus": "", "room": ""})
 
-        nested_tds = schedule_cell.find_all("td", recursive=False)
-        if len(nested_tds) >= 1:
-            instructors = parse_instructors(nested_tds[0].decode_contents())
-        if len(nested_tds) >= 2:
-            notes = parse_notes(nested_tds[1].decode_contents())
+        # Try to extract instructors and notes from nested TDs (old structure)
+        instructors, notes = extract_from_schedule_cell(schedule_cell)
+
+    # If instructors/notes not found in schedule cell, try sibling cells (new structure)
+    if not instructors and not notes:
+        instructors, notes = extract_from_sibling_cells(row_cells, section_type_index)
 
     return schedule, instructors, notes, catalog_number, is_cancelled
 

--- a/scraping/scrapers/tests/helpers/test_course_parsing.py
+++ b/scraping/scrapers/tests/helpers/test_course_parsing.py
@@ -153,6 +153,78 @@ class TestParseSectionRow(unittest.TestCase):
         self.assertEqual(detail["catalogNumber"], "E77J01")
         self.assertEqual(detail["schedule"][0]["room"], "WC 117")
 
+    def test_section_row_with_instructors_notes_in_sibling_cells(self):
+        """Newer HTML structure keeps instructors/notes in sibling cells."""
+        course = parse_course_header(BeautifulSoup("""<tr>
+            <td class=\"bodytext\">Faculty</td>
+            <td class=\"bodytext\">EDUC</td>
+            <td class=\"bodytext\">FW</td>
+            <td class=\"bodytext\" colspan=\"2\">Test Course</td>
+        </tr>""", "html.parser").find("tr"))
+
+        row_html = """<tr>
+            <td>1005 3.00 A</td>
+            <td>EN</td>
+            <td>LECT</td>
+            <td>01</td>
+            <td>Z99Z01</td>
+            <td>
+                <table>
+                    <tr>
+                        <td>M</td>
+                        <td>11:30</td>
+                        <td>170</td>
+                        <td>Keele</td>
+                        <td>CLH E</td>
+                    </tr>
+                </table>
+            </td>
+            <td>Mary Smith</td>
+            <td>Bring calculator</td>
+        </tr>"""
+        row = BeautifulSoup(row_html, "html.parser").find("tr")
+        detail = parse_section_row(row.find_all("td", recursive=False), course)
+
+        self.assertIsNotNone(detail)
+        self.assertEqual(detail["instructors"], ["Mary Smith"])
+        self.assertEqual(detail["notes"], "Bring calculator")
+
+    def test_section_row_with_instructors_notes_nested_in_schedule_cell(self):
+        """Older HTML structure can embed instructors/notes inside schedule cell."""
+        course = parse_course_header(BeautifulSoup("""<tr>
+            <td class=\"bodytext\">Faculty</td>
+            <td class=\"bodytext\">EDUC</td>
+            <td class=\"bodytext\">FW</td>
+            <td class=\"bodytext\" colspan=\"2\">Test Course</td>
+        </tr>""", "html.parser").find("tr"))
+
+        row_html = """<tr>
+            <td>1006 3.00 B</td>
+            <td>EN</td>
+            <td>LECT</td>
+            <td>02</td>
+            <td>Y11Y02</td>
+            <td>
+                <table>
+                    <tr>
+                        <td>W</td>
+                        <td>14:30</td>
+                        <td>170</td>
+                        <td>Keele</td>
+                        <td>ACW 005</td>
+                    </tr>
+                </table>
+                <td>John Limnidis</td>
+                <td>(Backup)</td>
+            </td>
+        </tr>"""
+        row = BeautifulSoup(row_html, "html.parser").find("tr")
+        detail = parse_section_row(row.find_all("td", recursive=False), course)
+
+        self.assertIsNotNone(detail)
+        self.assertEqual(detail["instructors"], ["John Limnidis"])
+        self.assertEqual(detail["notes"], "(Backup)")
+
     def test_section_row_with_schedule_text(self):
         course = parse_course_header(BeautifulSoup("""<tr>
             <td class=\"bodytext\">Faculty</td>


### PR DESCRIPTION
Re-ran the scrapers on the updated source html files for Summer 2026. DB was then re-seeded.

Turns out these html files have a slightly different structure for instructor info and notes. Hence, I also updated the scraper script to support the new structure while also keeping support for the old structure. Test cases were updated as well.