### PR TITLE
Added caching support to core-api

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -52,25 +52,31 @@ func setupRouter(pool *pgxpool.Pool) *gin.Engine {
 
 	reviewRepo := repository.NewReviewRepository(pool)
 	reviewHandler := handlers.NewReviewHandler(reviewRepo)
+	cacheStore := middleware.NewResponseCacheStore()
 
 	router := gin.Default()
 
 	rateLimiter := middleware.NewRateLimiter(400, 1*time.Minute)
 	router.Use(rateLimiter.Limit())
 
+	const (
+		catalogTTL   = 6 * time.Hour
+		catalogStale = 24 * time.Hour
+	)
+
 	api := router.Group("/api/v1")
 	{
-		api.GET("/courses", courseHandler.GetCourses)
-		api.GET("/courses/paginated", courseHandler.GetPaginatedCourses)
-		api.GET("/courses/search", courseHandler.SearchCourses)
-		api.GET("/courses/:course_code", courseHandler.GetCoursesByCode)
-		api.GET("/instructors/:course_id", instructorHandler.GetInstructorsByCourseID)
-		api.GET("/sections/:course_id", sectionHandler.GetSectionsByCourseID)
+		api.GET("/courses", middleware.CatalogHTTPCache(cacheStore, catalogTTL, catalogStale), courseHandler.GetCourses)
+		api.GET("/courses/paginated", middleware.CatalogHTTPCache(cacheStore, catalogTTL, catalogStale), courseHandler.GetPaginatedCourses)
+		api.GET("/courses/search", middleware.CatalogHTTPCache(cacheStore, catalogTTL, catalogStale), courseHandler.SearchCourses)
+		api.GET("/courses/:course_code", middleware.CatalogHTTPCache(cacheStore, catalogTTL, catalogStale), courseHandler.GetCoursesByCode)
+		api.GET("/instructors/:course_id", middleware.CatalogHTTPCache(cacheStore, catalogTTL, catalogStale), instructorHandler.GetInstructorsByCourseID)
+		api.GET("/sections/:course_id", middleware.CatalogHTTPCache(cacheStore, catalogTTL, catalogStale), sectionHandler.GetSectionsByCourseID)
 
 		// Review endpoints
-		api.GET("/reviews", reviewHandler.GetAllReviews)
-		api.GET("/courses/:course_code/reviews", reviewHandler.GetReviews)
-		api.POST("/courses/:course_code/reviews", reviewHandler.CreateReview)
+		api.GET("/reviews", middleware.NoStore(), reviewHandler.GetAllReviews)
+		api.GET("/courses/:course_code/reviews", middleware.NoStore(), reviewHandler.GetReviews)
+		api.POST("/courses/:course_code/reviews", middleware.NoStore(), reviewHandler.CreateReview)
 	}
 	return router
 }

--- a/internal/middleware/response_cache.go
+++ b/internal/middleware/response_cache.go
@@ -1,0 +1,350 @@
+package middleware
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+const defaultMaxCacheEntries = 2000
+
+type cachedResponse struct {
+	status      int
+	contentType string
+	body        []byte
+	eTag        string
+	lastMod     time.Time
+	expires     time.Time
+}
+
+// ResponseCacheStore holds cached HTTP response bodies for GET handlers.
+type ResponseCacheStore struct {
+	mu         sync.RWMutex
+	data       map[string]cachedResponse
+	maxEntries int
+}
+
+// NewResponseCacheStore creates an empty cache.
+func NewResponseCacheStore() *ResponseCacheStore {
+	return &ResponseCacheStore{
+		data:       make(map[string]cachedResponse),
+		maxEntries: defaultMaxCacheEntries,
+	}
+}
+
+func cacheKey(c *gin.Context) string {
+	q := c.Request.URL.Query()
+	keys := make([]string, 0, len(q))
+	for k := range q {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteString(c.Request.Method)
+	b.WriteByte(' ')
+	b.WriteString(c.Request.URL.Path)
+	if len(keys) > 0 {
+		b.WriteByte('?')
+		pairIndex := 0
+		for _, k := range keys {
+			vals := q[k]
+			if len(vals) == 0 {
+				if pairIndex > 0 {
+					b.WriteByte('&')
+				}
+				b.WriteString(url.QueryEscape(k))
+				b.WriteByte('=')
+				pairIndex++
+				continue
+			}
+			for _, v := range vals {
+				if pairIndex > 0 {
+					b.WriteByte('&')
+				}
+				b.WriteString(url.QueryEscape(k))
+				b.WriteByte('=')
+				b.WriteString(url.QueryEscape(v))
+				pairIndex++
+			}
+		}
+	}
+	return b.String()
+}
+
+type responseCaptureWriter struct {
+	gin.ResponseWriter
+	orig   gin.ResponseWriter
+	header http.Header
+	body   *bytes.Buffer
+	status int
+	size   int
+}
+
+func newResponseCaptureWriter(orig gin.ResponseWriter) *responseCaptureWriter {
+	return &responseCaptureWriter{
+		ResponseWriter: orig,
+		orig:           orig,
+		header:         make(http.Header),
+		body:           &bytes.Buffer{},
+		status:         0,
+		size:           -1,
+	}
+}
+
+func (w *responseCaptureWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *responseCaptureWriter) WriteHeader(code int) {
+	w.status = code
+}
+
+func (w *responseCaptureWriter) Write(b []byte) (int, error) {
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+	if w.size < 0 {
+		w.size = 0
+	}
+	w.body.Write(b)
+	w.size += len(b)
+	return len(b), nil
+}
+
+func (w *responseCaptureWriter) WriteString(s string) (int, error) {
+	return w.Write([]byte(s))
+}
+
+func (w *responseCaptureWriter) Status() int {
+	if w.status == 0 {
+		return http.StatusOK
+	}
+	return w.status
+}
+
+func (w *responseCaptureWriter) Size() int {
+	return w.size
+}
+
+func (w *responseCaptureWriter) Written() bool {
+	return w.size >= 0 || w.status != 0
+}
+
+func (w *responseCaptureWriter) WriteHeaderNow() {}
+
+func (w *responseCaptureWriter) Flush() {}
+
+func (w *responseCaptureWriter) Pusher() http.Pusher {
+	return w.orig.Pusher()
+}
+
+// CatalogHTTPCache stores successful catalog GET responses and serves
+// consistent HTTP caching headers/validators (Cache-Control, ETag, Last-Modified).
+func CatalogHTTPCache(store *ResponseCacheStore, ttl time.Duration, staleWhileRevalidate time.Duration) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if c.Request.Method != http.MethodGet {
+			c.Next()
+			return
+		}
+
+		key := cacheKey(c)
+
+		store.mu.RLock()
+		ent, ok := store.data[key]
+		store.mu.RUnlock()
+		if ok && !time.Now().Before(ent.expires) {
+			store.mu.Lock()
+			delete(store.data, key)
+			store.mu.Unlock()
+			ok = false
+		}
+		if ok && time.Now().Before(ent.expires) {
+			setCatalogHeaders(c, ttl, staleWhileRevalidate, ent.eTag, ent.lastMod)
+			if isNotModified(c, ent.eTag, ent.lastMod) {
+				c.Status(http.StatusNotModified)
+				c.Abort()
+				return
+			}
+			if ent.contentType != "" {
+				c.Header("Content-Type", ent.contentType)
+			}
+			c.Status(ent.status)
+			_, _ = c.Writer.Write(ent.body)
+			c.Abort()
+			return
+		}
+
+		origWriter := c.Writer
+		capture := newResponseCaptureWriter(origWriter)
+		c.Writer = capture
+
+		c.Next()
+
+		status := capture.status
+		if status == 0 {
+			status = http.StatusOK
+		}
+		if status != http.StatusOK || capture.body.Len() == 0 {
+			for hk, vals := range capture.header {
+				for _, v := range vals {
+					origWriter.Header().Add(hk, v)
+				}
+			}
+			origWriter.WriteHeader(status)
+			_, _ = origWriter.Write(capture.body.Bytes())
+			c.Writer = origWriter
+			return
+		}
+
+		lastMod := time.Now().UTC()
+		eTag := buildWeakETag(capture.body.Bytes())
+		ct := capture.header.Get("Content-Type")
+		store.mu.Lock()
+		store.cleanupExpiredLocked(lastMod)
+		if store.maxEntries > 0 && len(store.data) >= store.maxEntries {
+			store.evictOldestLocked(len(store.data) - store.maxEntries + 1)
+		}
+		store.data[key] = cachedResponse{
+			status:      http.StatusOK,
+			contentType: ct,
+			body:        append([]byte(nil), capture.body.Bytes()...),
+			eTag:        eTag,
+			lastMod:     lastMod,
+			expires:     time.Now().Add(ttl),
+		}
+		store.mu.Unlock()
+
+		for hk, vals := range capture.header {
+			for _, v := range vals {
+				origWriter.Header().Add(hk, v)
+			}
+		}
+		maxAge := int(ttl.Seconds())
+		if maxAge < 0 {
+			maxAge = 0
+		}
+		stale := int(staleWhileRevalidate.Seconds())
+		if stale < 0 {
+			stale = 0
+		}
+		origWriter.Header().Set("Cache-Control", "public, max-age="+strconv.Itoa(maxAge)+", stale-while-revalidate="+strconv.Itoa(stale))
+		origWriter.Header().Set("ETag", eTag)
+		origWriter.Header().Set("Last-Modified", lastMod.Format(http.TimeFormat))
+		if catalogVersion := strings.TrimSpace(os.Getenv("CATALOG_VERSION")); catalogVersion != "" {
+			origWriter.Header().Set("X-Catalog-Version", catalogVersion)
+		}
+		origWriter.WriteHeader(status)
+		_, _ = origWriter.Write(capture.body.Bytes())
+		c.Writer = origWriter
+	}
+}
+
+// NoStore marks responses as uncacheable by browsers, intermediaries, and clients.
+func NoStore() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Header("Cache-Control", "no-store")
+		c.Next()
+	}
+}
+
+func setCatalogHeaders(c *gin.Context, ttl time.Duration, staleWhileRevalidate time.Duration, eTag string, lastMod time.Time) {
+	maxAge := int(ttl.Seconds())
+	if maxAge < 0 {
+		maxAge = 0
+	}
+	stale := int(staleWhileRevalidate.Seconds())
+	if stale < 0 {
+		stale = 0
+	}
+	c.Header("Cache-Control", "public, max-age="+strconv.Itoa(maxAge)+", stale-while-revalidate="+strconv.Itoa(stale))
+	if eTag != "" {
+		c.Header("ETag", eTag)
+	}
+	if !lastMod.IsZero() {
+		c.Header("Last-Modified", lastMod.Format(http.TimeFormat))
+	}
+	if catalogVersion := strings.TrimSpace(os.Getenv("CATALOG_VERSION")); catalogVersion != "" {
+		c.Header("X-Catalog-Version", catalogVersion)
+	}
+}
+
+func buildWeakETag(body []byte) string {
+	sum := sha256.Sum256(body)
+	return `W/"` + hex.EncodeToString(sum[:]) + `"`
+}
+
+func isNotModified(c *gin.Context, eTag string, lastMod time.Time) bool {
+	ifNoneMatch := strings.TrimSpace(c.GetHeader("If-None-Match"))
+	if ifNoneMatch != "" && eTag != "" {
+		// RFC allows comma-separated list; wildcard is also accepted.
+		if ifNoneMatch == "*" || matchETagList(ifNoneMatch, eTag) {
+			return true
+		}
+	}
+
+	ifModifiedSince := strings.TrimSpace(c.GetHeader("If-Modified-Since"))
+	if ifModifiedSince != "" && !lastMod.IsZero() {
+		if t, err := time.Parse(http.TimeFormat, ifModifiedSince); err == nil {
+			// HTTP date is second-granularity.
+			if !lastMod.After(t.Add(time.Second - time.Nanosecond)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func matchETagList(headerValue string, eTag string) bool {
+	parts := strings.Split(headerValue, ",")
+	for _, p := range parts {
+		if strings.TrimSpace(p) == eTag {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *ResponseCacheStore) cleanupExpiredLocked(now time.Time) {
+	for k, v := range s.data {
+		if !now.Before(v.expires) {
+			delete(s.data, k)
+		}
+	}
+}
+
+func (s *ResponseCacheStore) evictOldestLocked(n int) {
+	if n <= 0 || len(s.data) == 0 {
+		return
+	}
+	if n >= len(s.data) {
+		for k := range s.data {
+			delete(s.data, k)
+		}
+		return
+	}
+
+	type kv struct {
+		key     string
+		expires time.Time
+	}
+	all := make([]kv, 0, len(s.data))
+	for k, v := range s.data {
+		all = append(all, kv{key: k, expires: v.expires})
+	}
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].expires.Before(all[j].expires)
+	})
+	for i := 0; i < n; i++ {
+		delete(s.data, all[i].key)
+	}
+}

--- a/internal/middleware/response_cache_test.go
+++ b/internal/middleware/response_cache_test.go
@@ -1,0 +1,130 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResponseCache_SecondHitUsesStore(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := NewResponseCacheStore()
+	var calls atomic.Int32
+
+	r := gin.New()
+	r.GET("/x", CatalogHTTPCache(store, time.Minute, time.Hour), func(c *gin.Context) {
+		calls.Add(1)
+		c.JSON(http.StatusOK, gin.H{"n": int(calls.Load())})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	w1 := httptest.NewRecorder()
+	r.ServeHTTP(w1, req)
+	assert.Equal(t, http.StatusOK, w1.Code)
+	assert.Contains(t, w1.Body.String(), `"n":1`)
+	assert.Equal(t, int32(1), calls.Load())
+	assert.Contains(t, w1.Header().Get("Cache-Control"), "max-age=60")
+	assert.NotEmpty(t, w1.Header().Get("ETag"))
+	assert.NotEmpty(t, w1.Header().Get("Last-Modified"))
+
+	w2 := httptest.NewRecorder()
+	r.ServeHTTP(w2, httptest.NewRequest(http.MethodGet, "/x", nil))
+	assert.Equal(t, http.StatusOK, w2.Code)
+	assert.Contains(t, w2.Body.String(), `"n":1`)
+	assert.Equal(t, int32(1), calls.Load(), "handler should not run on cache hit")
+	assert.Contains(t, w2.Header().Get("Cache-Control"), "max-age=60")
+	assert.NotEmpty(t, w2.Header().Get("ETag"))
+	assert.NotEmpty(t, w2.Header().Get("Last-Modified"))
+}
+
+func TestResponseCache_DifferentQueryDifferentEntry(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := NewResponseCacheStore()
+	var calls atomic.Int32
+
+	r := gin.New()
+	r.GET("/q", CatalogHTTPCache(store, time.Minute, time.Hour), func(c *gin.Context) {
+		calls.Add(1)
+		c.JSON(http.StatusOK, gin.H{"q": c.Query("a")})
+	})
+
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/q?a=1", nil))
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/q?a=2", nil))
+	assert.Equal(t, int32(2), calls.Load())
+}
+
+func TestResponseCache_RepeatedQueryParamsHaveDistinctKeys(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := NewResponseCacheStore()
+	var calls atomic.Int32
+
+	r := gin.New()
+	r.GET("/q", CatalogHTTPCache(store, time.Minute, time.Hour), func(c *gin.Context) {
+		calls.Add(1)
+		c.JSON(http.StatusOK, gin.H{"a": c.QueryArray("a")})
+	})
+
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/q?a=1&a=2", nil))
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/q?a=1", nil))
+	assert.Equal(t, int32(2), calls.Load())
+}
+
+func TestCatalogHTTPCache_Returns304WithIfNoneMatch(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := NewResponseCacheStore()
+
+	r := gin.New()
+	r.GET("/catalog", CatalogHTTPCache(store, time.Minute, time.Hour), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w1 := httptest.NewRecorder()
+	r.ServeHTTP(w1, httptest.NewRequest(http.MethodGet, "/catalog", nil))
+	etag := w1.Header().Get("ETag")
+	assert.NotEmpty(t, etag)
+
+	req2 := httptest.NewRequest(http.MethodGet, "/catalog", nil)
+	req2.Header.Set("If-None-Match", etag)
+	w2 := httptest.NewRecorder()
+	r.ServeHTTP(w2, req2)
+
+	assert.Equal(t, http.StatusNotModified, w2.Code)
+	assert.Empty(t, w2.Body.String())
+}
+
+func TestNoStore_SetsHeader(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	r.GET("/reviews", NoStore(), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/reviews", nil))
+	assert.Equal(t, "no-store", w.Header().Get("Cache-Control"))
+}
+
+func TestCatalogHTTPCache_EvictsWhenMaxEntriesExceeded(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := NewResponseCacheStore()
+	store.maxEntries = 2
+
+	r := gin.New()
+	r.GET("/q", CatalogHTTPCache(store, time.Minute, time.Hour), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"q": c.Query("k")})
+	})
+
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/q?k=1", nil))
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/q?k=2", nil))
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/q?k=3", nil))
+
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+	assert.LessOrEqual(t, len(store.data), 2)
+}


### PR DESCRIPTION
- HTTP caching for catalogue GET endpoints with `Cache-Control: public, max-age=21600, stale-while-revalidate=86400`, plus ETag and Last-Modified validators.
- Implemented conditional requests (If-None-Match / If-Modified-Since) to return 304 Not Modified when catalogue responses are unchanged.
- Set review endpoints (GET + POST) to Cache-Control: no-store so review data is always fresh and not cached client/proxy-side.
- miss-path header ordering via full buffering
- collision-safe query cache keys (including repeated params)
- bounded in-memory cache with expiry pruning + eviction.
- Added/updated tests for first-hit headers, cache hits, 304 behaviour, repeated-query keys, and max-entry eviction; test suite and lints pass.