### PR TITLE
automated source to seeding process with a POST endpoint

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -86,7 +86,7 @@ func setupRouter(pool *pgxpool.Pool, cfg *config.Config) *gin.Engine {
 		api.GET("/courses/:course_code/reviews", middleware.NoStore(), reviewHandler.GetReviews)
 		api.POST("/courses/:course_code/reviews", middleware.NoStore(), reviewHandler.CreateReview)
 
-		api.POST("/admin/seed-pipeline", middleware.NoStore(), seedPipelineHandler.Post)
+		api.POST("/admin/seed/pipeline", middleware.NoStore(), seedPipelineHandler.Post)
 	}
 	return router
 }

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"log"
+	"os"
 	"time"
 	"yuplan/internal/config"
 	"yuplan/internal/database"
@@ -54,13 +55,12 @@ func setupRouter(pool *pgxpool.Pool, cfg *config.Config) *gin.Engine {
 	reviewHandler := handlers.NewReviewHandler(reviewRepo)
 	cacheStore := middleware.NewResponseCacheStore()
 
-	seedPipelineHandler := handlers.NewSeedPipelineHandler(
-		cfg.SeedPipelineToken,
-		cfg.SeedPipelineRepoRoot,
-		cfg.SeedPipelinePython,
-		cfg.SeedPipelineApplyDB,
-		cfg.SeedPipelineTimeout,
-	)
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		log.Printf("Getwd for seed pipeline: %v, using .", err)
+		repoRoot = "."
+	}
+	seedPipelineHandler := handlers.NewSeedPipelineHandler(cfg.SeedPipelineToken, cfg.DatabaseURL, repoRoot)
 
 	router := gin.Default()
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -24,7 +24,7 @@ func main() {
 	}
 	defer pool.Close()
 
-	router := setupRouter(pool)
+	router := setupRouter(pool, cfg)
 
 	if err := startServer(router, cfg.Port); err != nil {
 		log.Fatalf("Failed to start server: %v", err)
@@ -39,7 +39,7 @@ func initDatabase(ctx context.Context, databaseURL string) (*pgxpool.Pool, error
 	return pool, nil
 }
 
-func setupRouter(pool *pgxpool.Pool) *gin.Engine {
+func setupRouter(pool *pgxpool.Pool, cfg *config.Config) *gin.Engine {
 	courseRepo := repository.NewCourseRepository(pool)
 	sectionActivityRepo := repository.NewSectionActivityRepository(pool)
 	sectionRepo := repository.NewSectionRepository(pool, sectionActivityRepo)
@@ -53,6 +53,14 @@ func setupRouter(pool *pgxpool.Pool) *gin.Engine {
 	reviewRepo := repository.NewReviewRepository(pool)
 	reviewHandler := handlers.NewReviewHandler(reviewRepo)
 	cacheStore := middleware.NewResponseCacheStore()
+
+	seedPipelineHandler := handlers.NewSeedPipelineHandler(
+		cfg.SeedPipelineToken,
+		cfg.SeedPipelineRepoRoot,
+		cfg.SeedPipelinePython,
+		cfg.SeedPipelineApplyDB,
+		cfg.SeedPipelineTimeout,
+	)
 
 	router := gin.Default()
 
@@ -77,6 +85,8 @@ func setupRouter(pool *pgxpool.Pool) *gin.Engine {
 		api.GET("/reviews", middleware.NoStore(), reviewHandler.GetAllReviews)
 		api.GET("/courses/:course_code/reviews", middleware.NoStore(), reviewHandler.GetReviews)
 		api.POST("/courses/:course_code/reviews", middleware.NoStore(), reviewHandler.CreateReview)
+
+		api.POST("/admin/seed-pipeline", middleware.NoStore(), seedPipelineHandler.Post)
 	}
 	return router
 }

--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"yuplan/internal/config"
 )
 
 func TestSetupRouter_RegistersCourseRoutes(t *testing.T) {
 	// Passing nil is OK here: setupRouter only wires dependencies.
 	// We won't execute any handlers that require a real database.
-	r := setupRouter(nil)
+	r := setupRouter(nil, &config.Config{})
 
 	routes := r.Routes()
 	assert.NotEmpty(t, routes)
@@ -25,6 +26,7 @@ func TestSetupRouter_RegistersCourseRoutes(t *testing.T) {
 	assert.True(t, seen[http.MethodGet+" /api/v1/courses"], "expected GET /api/v1/courses route")
 	assert.True(t, seen[http.MethodGet+" /api/v1/courses/search"], "expected GET /api/v1/courses/search route")
 	assert.True(t, seen[http.MethodGet+" /api/v1/courses/:course_code"], "expected GET /api/v1/courses/:course_code route")
+	assert.True(t, seen[http.MethodPost+" /api/v1/admin/seed-pipeline"], "expected POST /api/v1/admin/seed-pipeline route")
 }
 
 func TestInitDatabase_InvalidURL_ReturnsError(t *testing.T) {

--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -26,7 +26,7 @@ func TestSetupRouter_RegistersCourseRoutes(t *testing.T) {
 	assert.True(t, seen[http.MethodGet+" /api/v1/courses"], "expected GET /api/v1/courses route")
 	assert.True(t, seen[http.MethodGet+" /api/v1/courses/search"], "expected GET /api/v1/courses/search route")
 	assert.True(t, seen[http.MethodGet+" /api/v1/courses/:course_code"], "expected GET /api/v1/courses/:course_code route")
-	assert.True(t, seen[http.MethodPost+" /api/v1/admin/seed-pipeline"], "expected POST /api/v1/admin/seed-pipeline route")
+	assert.True(t, seen[http.MethodPost+" /api/v1/admin/seed/pipeline"], "expected POST /api/v1/admin/seed/pipeline route")
 }
 
 func TestInitDatabase_InvalidURL_ReturnsError(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,7 +11,7 @@ type Config struct {
 	DatabaseURL string
 	Port        string
 
-	// POST /api/v1/admin/seed-pipeline (Bearer SEED_PIPELINE_TOKEN)
+	// POST /api/v1/admin/seed/pipeline (Bearer SEED_PIPELINE_TOKEN)
 	SeedPipelineToken    string
 	SeedPipelineRepoRoot string
 	SeedPipelinePython   string

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,21 +2,17 @@ package config
 
 import (
 	"os"
-	"strconv"
 	"strings"
-	"time"
 )
 
 type Config struct {
 	DatabaseURL string
 	Port        string
 
-	// POST /api/v1/admin/seed/pipeline (Bearer SEED_PIPELINE_TOKEN)
-	SeedPipelineToken    string
-	SeedPipelineRepoRoot string
-	SeedPipelinePython   string
-	SeedPipelineApplyDB  bool
-	SeedPipelineTimeout  time.Duration
+	// POST /api/v1/admin/seed/pipeline — Bearer shared secret (you choose the value).
+	// Everything else for that route is hardcoded (python3, 45m timeout, cwd = repo root at startup).
+	// If DATABASE_URL is set, the pipeline also runs scripts/seed.sh after generating db/seed.sql.
+	SeedPipelineToken string
 }
 
 func Load() *Config {
@@ -24,11 +20,7 @@ func Load() *Config {
 		DatabaseURL: getEnv("DATABASE_URL", "postgres://postgres:postgres@localhost:5432/yuplan?sslmode=disable"),
 		Port:        getEnv("PORT", "8080"),
 
-		SeedPipelineToken:    strings.TrimSpace(getEnv("SEED_PIPELINE_TOKEN", "")),
-		SeedPipelineRepoRoot: getEnv("YUPLAN_REPO_ROOT", "."),
-		SeedPipelinePython:   getEnv("SEED_PIPELINE_PYTHON", "python3"),
-		SeedPipelineApplyDB:  getEnvBool("SEED_PIPELINE_APPLY_DB", false),
-		SeedPipelineTimeout:  getEnvDurationMinutes("SEED_PIPELINE_TIMEOUT_MINUTES", 45),
+		SeedPipelineToken: strings.TrimSpace(getEnv("SEED_PIPELINE_TOKEN", "")),
 	}
 }
 
@@ -37,24 +29,4 @@ func getEnv(key, defaultValue string) string {
 		return value
 	}
 	return defaultValue
-}
-
-func getEnvBool(key string, defaultVal bool) bool {
-	s := strings.TrimSpace(strings.ToLower(os.Getenv(key)))
-	if s == "" {
-		return defaultVal
-	}
-	return s == "1" || s == "true" || s == "yes" || s == "on"
-}
-
-func getEnvDurationMinutes(key string, defaultMins int) time.Duration {
-	s := strings.TrimSpace(os.Getenv(key))
-	if s == "" {
-		return time.Duration(defaultMins) * time.Minute
-	}
-	n, err := strconv.Atoi(s)
-	if err != nil || n <= 0 {
-		return time.Duration(defaultMins) * time.Minute
-	}
-	return time.Duration(n) * time.Minute
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,17 +2,33 @@ package config
 
 import (
 	"os"
+	"strconv"
+	"strings"
+	"time"
 )
 
 type Config struct {
 	DatabaseURL string
 	Port        string
+
+	// POST /api/v1/admin/seed-pipeline (Bearer SEED_PIPELINE_TOKEN)
+	SeedPipelineToken    string
+	SeedPipelineRepoRoot string
+	SeedPipelinePython   string
+	SeedPipelineApplyDB  bool
+	SeedPipelineTimeout  time.Duration
 }
 
 func Load() *Config {
 	return &Config{
 		DatabaseURL: getEnv("DATABASE_URL", "postgres://postgres:postgres@localhost:5432/yuplan?sslmode=disable"),
 		Port:        getEnv("PORT", "8080"),
+
+		SeedPipelineToken:    strings.TrimSpace(getEnv("SEED_PIPELINE_TOKEN", "")),
+		SeedPipelineRepoRoot: getEnv("YUPLAN_REPO_ROOT", "."),
+		SeedPipelinePython:   getEnv("SEED_PIPELINE_PYTHON", "python3"),
+		SeedPipelineApplyDB:  getEnvBool("SEED_PIPELINE_APPLY_DB", false),
+		SeedPipelineTimeout:  getEnvDurationMinutes("SEED_PIPELINE_TIMEOUT_MINUTES", 45),
 	}
 }
 
@@ -21,4 +37,24 @@ func getEnv(key, defaultValue string) string {
 		return value
 	}
 	return defaultValue
+}
+
+func getEnvBool(key string, defaultVal bool) bool {
+	s := strings.TrimSpace(strings.ToLower(os.Getenv(key)))
+	if s == "" {
+		return defaultVal
+	}
+	return s == "1" || s == "true" || s == "yes" || s == "on"
+}
+
+func getEnvDurationMinutes(key string, defaultMins int) time.Duration {
+	s := strings.TrimSpace(os.Getenv(key))
+	if s == "" {
+		return time.Duration(defaultMins) * time.Minute
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil || n <= 0 {
+		return time.Duration(defaultMins) * time.Minute
+	}
+	return time.Duration(n) * time.Minute
 }

--- a/internal/handlers/seed_pipeline_env_test.go
+++ b/internal/handlers/seed_pipeline_env_test.go
@@ -1,0 +1,19 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnvWithSISCookie_OverridesExisting(t *testing.T) {
+	base := []string{"PATH=/bin", "YORK_SIS_COOKIE=old", "HOME=/tmp"}
+	out := envWithSISCookie(base, "a=b; c=d")
+
+	assert.Equal(t, []string{"PATH=/bin", "HOME=/tmp", "YORK_SIS_COOKIE=a=b; c=d"}, out)
+}
+
+func TestEnvWithSISCookie_EmptyLeavesBase(t *testing.T) {
+	base := []string{"PATH=/bin", "YORK_SIS_COOKIE=keep"}
+	assert.Equal(t, base, envWithSISCookie(base, ""))
+}

--- a/internal/handlers/seed_pipeline_handler.go
+++ b/internal/handlers/seed_pipeline_handler.go
@@ -1,0 +1,146 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// SeedPipelineHandler runs scripts/run_seed_pipeline.py (fetch → scrape → db/seed.sql, optional DB apply).
+type SeedPipelineHandler struct {
+	mu       sync.Mutex
+	token    string
+	repoRoot string
+	python   string
+	applyDB  bool
+	timeout  time.Duration
+}
+
+func NewSeedPipelineHandler(token, repoRoot, python string, applyDB bool, timeout time.Duration) *SeedPipelineHandler {
+	if timeout <= 0 {
+		timeout = 45 * time.Minute
+	}
+	if python == "" {
+		python = "python3"
+	}
+	if repoRoot == "" {
+		repoRoot = "."
+	}
+	return &SeedPipelineHandler{
+		token:    strings.TrimSpace(token),
+		repoRoot: repoRoot,
+		python:   python,
+		applyDB:  applyDB,
+		timeout:  timeout,
+	}
+}
+
+// Post triggers the pipeline asynchronously.
+// Optional JSON body: {"cookie":"…"} — forwarded as YORK_SIS_COOKIE for this run (overrides server env when non-empty).
+// Auth: Authorization: Bearer <SEED_PIPELINE_TOKEN>.
+func (h *SeedPipelineHandler) Post(c *gin.Context) {
+	if h.token == "" {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "seed pipeline not configured (set SEED_PIPELINE_TOKEN)"})
+		return
+	}
+
+	raw := strings.TrimSpace(c.GetHeader("Authorization"))
+	if !strings.HasPrefix(strings.ToLower(raw), "bearer ") {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "missing bearer token"})
+		return
+	}
+	got := strings.TrimSpace(raw[7:])
+	if subtle.ConstantTimeCompare([]byte(got), []byte(h.token)) != 1 {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	sisCookie, ok := readOptionalSISCookieBody(c)
+	if !ok {
+		return
+	}
+
+	if !h.mu.TryLock() {
+		c.JSON(http.StatusConflict, gin.H{"error": "seed pipeline already running"})
+		return
+	}
+
+	go h.runLocked(sisCookie)
+
+	c.JSON(http.StatusAccepted, gin.H{"status": "accepted", "apply_db": h.applyDB})
+}
+
+func readOptionalSISCookieBody(c *gin.Context) (string, bool) {
+	body, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "could not read body"})
+		return "", false
+	}
+	trim := bytes.TrimSpace(body)
+	if len(trim) == 0 {
+		return "", true
+	}
+
+	var req struct {
+		Cookie string `json:"cookie"`
+	}
+	if err := json.Unmarshal(trim, &req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": `invalid json; use {} or {"cookie":"…"}`})
+		return "", false
+	}
+	return strings.TrimSpace(req.Cookie), true
+}
+
+// envWithSISCookie returns base env with YORK_SIS_COOKIE set to sisCookie when non-empty (replacing any existing value).
+func envWithSISCookie(base []string, sisCookie string) []string {
+	if sisCookie == "" {
+		return base
+	}
+	out := make([]string, 0, len(base)+1)
+	for _, kv := range base {
+		if strings.HasPrefix(kv, "YORK_SIS_COOKIE=") {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return append(out, "YORK_SIS_COOKIE="+sisCookie)
+}
+
+func (h *SeedPipelineHandler) runLocked(sisCookie string) {
+	defer h.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), h.timeout)
+	defer cancel()
+
+	script := filepath.Join(h.repoRoot, "scripts", "run_seed_pipeline.py")
+	args := []string{script}
+	if h.applyDB {
+		args = append(args, "--apply-db")
+	}
+
+	cmd := exec.CommandContext(ctx, h.python, args...)
+	cmd.Dir = h.repoRoot
+	cmd.Env = envWithSISCookie(os.Environ(), sisCookie)
+
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+
+	if err := cmd.Run(); err != nil {
+		log.Printf("seed pipeline failed: %v\n%s", err, buf.String())
+		return
+	}
+	log.Printf("seed pipeline finished:\n%s", buf.String())
+}

--- a/internal/handlers/seed_pipeline_handler.go
+++ b/internal/handlers/seed_pipeline_handler.go
@@ -18,32 +18,30 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// SeedPipelineHandler runs scripts/run_seed_pipeline.py (fetch → scrape → db/seed.sql, optional DB apply).
+const (
+	seedPipelinePython  = "python3"
+	seedPipelineTimeout = 45 * time.Minute
+)
+
+// SeedPipelineHandler runs scripts/run_seed_pipeline.py (fetch → scrape → db/seed.sql).
+// If databaseURL is non-empty, also passes --apply-db so scripts/seed.sh runs (uses DATABASE_URL from the child env).
 type SeedPipelineHandler struct {
 	mu       sync.Mutex
 	token    string
 	repoRoot string
-	python   string
 	applyDB  bool
-	timeout  time.Duration
 }
 
-func NewSeedPipelineHandler(token, repoRoot, python string, applyDB bool, timeout time.Duration) *SeedPipelineHandler {
-	if timeout <= 0 {
-		timeout = 45 * time.Minute
-	}
-	if python == "" {
-		python = "python3"
-	}
+// NewSeedPipelineHandler configures the admin seed route. Repo root is usually os.Getwd() at startup (deploy from repo root).
+// applyDB is true when databaseURL is non-empty so the child process runs scripts/seed.sh (inherits DATABASE_URL).
+func NewSeedPipelineHandler(token, databaseURL, repoRoot string) *SeedPipelineHandler {
 	if repoRoot == "" {
 		repoRoot = "."
 	}
 	return &SeedPipelineHandler{
 		token:    strings.TrimSpace(token),
 		repoRoot: repoRoot,
-		python:   python,
-		applyDB:  applyDB,
-		timeout:  timeout,
+		applyDB:  strings.TrimSpace(databaseURL) != "",
 	}
 }
 
@@ -121,7 +119,7 @@ func envWithSISCookie(base []string, sisCookie string) []string {
 func (h *SeedPipelineHandler) runLocked(sisCookie string) {
 	defer h.mu.Unlock()
 
-	ctx, cancel := context.WithTimeout(context.Background(), h.timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), seedPipelineTimeout)
 	defer cancel()
 
 	script := filepath.Join(h.repoRoot, "scripts", "run_seed_pipeline.py")
@@ -130,7 +128,7 @@ func (h *SeedPipelineHandler) runLocked(sisCookie string) {
 		args = append(args, "--apply-db")
 	}
 
-	cmd := exec.CommandContext(ctx, h.python, args...)
+	cmd := exec.CommandContext(ctx, seedPipelinePython, args...)
 	cmd.Dir = h.repoRoot
 	cmd.Env = envWithSISCookie(os.Environ(), sisCookie)
 

--- a/internal/handlers/seed_pipeline_handler_test.go
+++ b/internal/handlers/seed_pipeline_handler_test.go
@@ -1,0 +1,55 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSeedPipelineHandler_Post_NotConfigured(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := NewSeedPipelineHandler("", ".", "python3", false, time.Minute)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/admin/seed-pipeline", nil)
+
+	h.Post(c)
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+func TestSeedPipelineHandler_Post_Unauthorized(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := NewSeedPipelineHandler("secret-token", ".", "python3", false, time.Minute)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/admin/seed-pipeline", nil)
+	c.Request.Header.Set("Authorization", "Bearer wrong")
+
+	h.Post(c)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestSeedPipelineHandler_Post_InvalidJSON(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := NewSeedPipelineHandler("secret-token", ".", "python3", false, time.Minute)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/seed-pipeline", strings.NewReader(`not-json`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer secret-token")
+	c.Request = req
+
+	h.Post(c)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}

--- a/internal/handlers/seed_pipeline_handler_test.go
+++ b/internal/handlers/seed_pipeline_handler_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -13,7 +12,7 @@ import (
 
 func TestSeedPipelineHandler_Post_NotConfigured(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	h := NewSeedPipelineHandler("", ".", "python3", false, time.Minute)
+	h := NewSeedPipelineHandler("", "", ".")
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
@@ -26,7 +25,7 @@ func TestSeedPipelineHandler_Post_NotConfigured(t *testing.T) {
 
 func TestSeedPipelineHandler_Post_Unauthorized(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	h := NewSeedPipelineHandler("secret-token", ".", "python3", false, time.Minute)
+	h := NewSeedPipelineHandler("secret-token", "postgres://localhost/db", ".")
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
@@ -40,7 +39,7 @@ func TestSeedPipelineHandler_Post_Unauthorized(t *testing.T) {
 
 func TestSeedPipelineHandler_Post_InvalidJSON(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	h := NewSeedPipelineHandler("secret-token", ".", "python3", false, time.Minute)
+	h := NewSeedPipelineHandler("secret-token", "postgres://localhost/db", ".")
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)

--- a/internal/handlers/seed_pipeline_handler_test.go
+++ b/internal/handlers/seed_pipeline_handler_test.go
@@ -17,7 +17,7 @@ func TestSeedPipelineHandler_Post_NotConfigured(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/admin/seed-pipeline", nil)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/admin/seed/pipeline", nil)
 
 	h.Post(c)
 
@@ -30,7 +30,7 @@ func TestSeedPipelineHandler_Post_Unauthorized(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/admin/seed-pipeline", nil)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/admin/seed/pipeline", nil)
 	c.Request.Header.Set("Authorization", "Bearer wrong")
 
 	h.Post(c)
@@ -44,7 +44,7 @@ func TestSeedPipelineHandler_Post_InvalidJSON(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/seed-pipeline", strings.NewReader(`not-json`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/seed/pipeline", strings.NewReader(`not-json`))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer secret-token")
 	c.Request = req

--- a/scripts/fetch_page_sources.py
+++ b/scripts/fetch_page_sources.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""
+Download York SIS timetable HTML into scraping/page_source/<term>/ using
+scraping/page_source/catalog_resource_map.json.
+
+Usage:
+  python scripts/fetch_page_sources.py --term fall-winter-2026-2027
+  python scripts/fetch_page_sources.py --term summer-2026
+  python scraping/scrapers/scrape.py --fall-winter-term fall-winter-2026-2027
+  python scripts/run_seed_pipeline.py
+  python scripts/fetch_page_sources.py --term fall-winter-2025-2026 --only schulich,science
+  python scripts/fetch_page_sources.py --term fall-winter-2026-2027 --dry-run
+  python scripts/fetch_page_sources.py --term fall-winter-2026-2027 --delay 0
+  # If you get Passport York HTML instead of timetables, pass session cookies from a logged-in browser:
+  python scripts/fetch_page_sources.py --term fall-winter-2026-2027 --cookie 'name=value; other=...'
+
+Requires network access to apps1.sis.yorku.ca (no extra pip packages).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def load_map(path: Path) -> dict:
+    with path.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+def looks_like_passport_block(body: bytes) -> bool:
+    """True if response is Passport York / SSO error instead of timetable HTML."""
+    if b"Passport York Login" in body or b"Passport York was unable" in body:
+        return True
+    if b"ppylogin" in body and b"alert-danger" in body:
+        return True
+    return False
+
+
+def html_bytes_for_disk(body: bytes) -> bytes:
+    """If the response is UTF-16 (some clients), normalize to UTF-8 for scrapers."""
+    if body.startswith((b"\xff\xfe", b"\xfe\xff")):
+        return body.decode("utf-16").encode("utf-8")
+    return body
+
+
+def fetch_url(
+    url: str,
+    *,
+    timeout: int = 60,
+    referer: str = "",
+    cookie: str = "",
+) -> bytes:
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+        ),
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "en-CA,en;q=0.9",
+    }
+    if referer:
+        headers["Referer"] = referer
+    if cookie:
+        headers["Cookie"] = cookie
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.read()
+
+
+def main() -> int:
+    root = repo_root()
+    default_map = root / "scraping" / "page_source" / "catalog_resource_map.json"
+    default_out = root / "scraping" / "page_source"
+
+    p = argparse.ArgumentParser(description="Fetch SIS timetable HTML into page_source/")
+    p.add_argument(
+        "--term",
+        required=True,
+        help="Term folder key, e.g. fall-winter-2026-2027",
+    )
+    p.add_argument("--map", type=Path, default=default_map, help="Path to catalog_resource_map.json")
+    p.add_argument(
+        "--out-dir",
+        type=Path,
+        default=default_out,
+        help="page_source root (default: scraping/page_source)",
+    )
+    p.add_argument(
+        "--only",
+        default="",
+        help="Comma-separated stems to fetch only (e.g. schulich,science)",
+    )
+    p.add_argument("--dry-run", action="store_true", help="Print URLs only; do not write files")
+    p.add_argument("--timeout", type=int, default=60, help="HTTP timeout seconds")
+    p.add_argument(
+        "--delay",
+        type=float,
+        default=10.0,
+        metavar="SEC",
+        help="Seconds to wait between HTTP requests (default: 10). Use 0 to disable.",
+    )
+    p.add_argument(
+        "--referer",
+        default="https://apps1.sis.yorku.ca/",
+        help="Referer header (default: apps1 SIS origin). Empty string disables.",
+    )
+    p.add_argument(
+        "--cookie",
+        default="",
+        metavar="STRING",
+        help="Raw Cookie header value from a logged-in browser session (DevTools → Network → request headers).",
+    )
+    args = p.parse_args()
+
+    if not args.map.is_file():
+        print(f"Map file not found: {args.map}", file=sys.stderr)
+        return 1
+
+    data = load_map(args.map)
+    base_url = data.get("base_url", "").rstrip("/") + "/"
+    terms = data.get("terms") or {}
+    if args.term not in terms:
+        print(f"Unknown term {args.term!r}. Known: {', '.join(sorted(terms))}", file=sys.stderr)
+        return 1
+
+    term_cfg = terms[args.term]
+    year_prefix = term_cfg.get("year_prefix")
+    stems = term_cfg.get("stem_to_faculty_code") or {}
+    if not year_prefix or not stems:
+        print(f"Term {args.term!r} missing year_prefix or stem_to_faculty_code", file=sys.stderr)
+        return 1
+
+    only = {s.strip() for s in args.only.split(",") if s.strip()}
+
+    dest_dir = args.out_dir / args.term
+    if not args.dry_run:
+        dest_dir.mkdir(parents=True, exist_ok=True)
+
+    errors = 0
+    fetch_index = 0
+    for stem, code in sorted(stems.items(), key=lambda x: x[0]):
+        if only and stem not in only:
+            continue
+        filename = f"{year_prefix}{code}.html"
+        url = base_url + filename
+        out_path = dest_dir / f"{stem}.html"
+
+        if args.dry_run:
+            print(f"{stem}: {url} -> {out_path.relative_to(root)}")
+            continue
+
+        if fetch_index > 0 and args.delay > 0:
+            time.sleep(args.delay)
+        fetch_index += 1
+
+        try:
+            body = fetch_url(
+                url,
+                timeout=args.timeout,
+                referer=(args.referer or ""),
+                cookie=(args.cookie or ""),
+            )
+        except urllib.error.HTTPError as e:
+            print(f"HTTP {e.code} {stem}: {url}", file=sys.stderr)
+            errors += 1
+            continue
+        except urllib.error.URLError as e:
+            print(f"URL error {stem}: {e.reason!r} ({url})", file=sys.stderr)
+            errors += 1
+            continue
+        except Exception as e:
+            print(f"Error {stem}: {e} ({url})", file=sys.stderr)
+            errors += 1
+            continue
+
+        if looks_like_passport_block(body):
+            print(
+                f"{stem}: got Passport York / SSO page instead of timetable (need --cookie from logged-in browser?). {url}",
+                file=sys.stderr,
+            )
+            errors += 1
+            continue
+
+        to_write = html_bytes_for_disk(body)
+        out_path.write_bytes(to_write)
+        print(f"Wrote {len(to_write)} bytes -> {out_path.relative_to(root)}")
+
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/refresh_timetables_and_seed.py
+++ b/scripts/refresh_timetables_and_seed.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+"""Backward-compatible alias for scripts/run_seed_pipeline.py."""
+
+import run_seed_pipeline
+
+if __name__ == "__main__":
+    raise SystemExit(run_seed_pipeline.main())

--- a/scripts/run_seed_pipeline.py
+++ b/scripts/run_seed_pipeline.py
@@ -4,7 +4,7 @@ Single entrypoint: fetch SIS HTML → run scrapers → generate db/seed.sql → 
 
 Environment (typical on a server):
   YORK_SIS_COOKIE     Cookie header for apps1 SIS (same as browser DevTools → Network).
-                        Overridden for one run when the Go POST /api/v1/admin/seed-pipeline
+                        Overridden for one run when the Go POST /api/v1/admin/seed/pipeline
                         body includes {"cookie":"…"}.
   SEED_PIPELINE_APPLY_DB  If "1"/"true"/"yes", run scripts/seed.sh after generating SQL
                           (needs DATABASE_URL and psql on PATH).

--- a/scripts/run_seed_pipeline.py
+++ b/scripts/run_seed_pipeline.py
@@ -2,12 +2,10 @@
 """
 Single entrypoint: fetch SIS HTML → run scrapers → generate db/seed.sql → optionally load DB.
 
-Environment (typical on a server):
-  YORK_SIS_COOKIE     Cookie header for apps1 SIS (same as browser DevTools → Network).
-                        Overridden for one run when the Go POST /api/v1/admin/seed/pipeline
-                        body includes {"cookie":"…"}.
-  SEED_PIPELINE_APPLY_DB  If "1"/"true"/"yes", run scripts/seed.sh after generating SQL
-                          (needs DATABASE_URL and psql on PATH).
+Environment:
+  DATABASE_URL          Used by seed.sh when you pass --apply-db (or API does, if DATABASE_URL was set at startup).
+  YORK_SIS_COOKIE       Optional fallback for SIS fetch; API usually sends cookie in POST JSON instead.
+  SEED_PIPELINE_APPLY_DB  CLI: "1"/"true" or --apply-db to run seed.sh after generating db/seed.sql.
 
 CLI (from repository root):
   python3 scripts/run_seed_pipeline.py

--- a/scripts/run_seed_pipeline.py
+++ b/scripts/run_seed_pipeline.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""
+Single entrypoint: fetch SIS HTML → run scrapers → generate db/seed.sql → optionally load DB.
+
+Environment (typical on a server):
+  YORK_SIS_COOKIE     Cookie header for apps1 SIS (same as browser DevTools → Network).
+                        Overridden for one run when the Go POST /api/v1/admin/seed-pipeline
+                        body includes {"cookie":"…"}.
+  SEED_PIPELINE_APPLY_DB  If "1"/"true"/"yes", run scripts/seed.sh after generating SQL
+                          (needs DATABASE_URL and psql on PATH).
+
+CLI (from repository root):
+  python3 scripts/run_seed_pipeline.py
+  python3 scripts/run_seed_pipeline.py --cookie '...' --apply-db
+  python3 scripts/run_seed_pipeline.py --skip-fetch   # reuse existing page_source HTML
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def run_step(cmd: list[str], *, cwd: Path) -> None:
+    print("\n+ " + " ".join(cmd), flush=True)
+    subprocess.run(cmd, cwd=cwd, check=True)
+
+
+def truthy_env(name: str) -> bool:
+    v = os.environ.get(name, "").strip().lower()
+    return v in ("1", "true", "yes", "on")
+
+
+def main() -> int:
+    root = repo_root()
+    py = sys.executable
+    fetch = str(root / "scripts" / "fetch_page_sources.py")
+    scrape = str(root / "scraping" / "scrapers" / "scrape.py")
+    gen = str(root / "scripts" / "generate_seed.py")
+    seed_sh = str(root / "scripts" / "seed.sh")
+
+    default_cookie = os.environ.get("YORK_SIS_COOKIE", "").strip()
+
+    p = argparse.ArgumentParser(
+        description="Fetch timetable HTML, scrape JSON, write db/seed.sql, optionally apply to DB."
+    )
+    p.add_argument(
+        "--fw-term",
+        default="fall-winter-2026-2027",
+        metavar="FOLDER",
+        help="page_source / data subfolder for fall-winter",
+    )
+    p.add_argument(
+        "--summer-term",
+        default="summer-2026",
+        metavar="FOLDER",
+        help="page_source subfolder for summer static HTML",
+    )
+    p.add_argument("--skip-fetch", action="store_true", help="Do not download HTML")
+    p.add_argument(
+        "--skip-summer-fetch",
+        action="store_true",
+        help="Only fetch fall/winter HTML (leave summer page_source as-is)",
+    )
+    p.add_argument("--only", default="", help="Comma-separated stems for fetch_page_sources --only")
+    p.add_argument("--fetch-delay", type=float, default=10.0, help="Seconds between fetch requests")
+    p.add_argument("--timeout", type=int, default=60, help="HTTP timeout for fetch")
+    p.add_argument("--referer", default="https://apps1.sis.yorku.ca/", help="Referer for fetch")
+    p.add_argument(
+        "--cookie",
+        default=default_cookie,
+        metavar="STRING",
+        help="Cookie header for SIS (default: YORK_SIS_COOKIE env)",
+    )
+    p.add_argument("--dry-run-fetch", action="store_true", help="Print fetch URLs only")
+    p.add_argument(
+        "--apply-db",
+        action="store_true",
+        help="Run scripts/seed.sh after generating db/seed.sql (or set SEED_PIPELINE_APPLY_DB)",
+    )
+    args = p.parse_args()
+
+    apply_db = args.apply_db or truthy_env("SEED_PIPELINE_APPLY_DB")
+
+    scrape_cwd = root / "scraping" / "scrapers"
+
+    if not args.skip_fetch:
+        if not (args.cookie or "").strip() and not args.dry_run_fetch:
+            print(
+                "Warning: no cookie set (use YORK_SIS_COOKIE or --cookie). "
+                "SIS may return Passport York instead of timetables.",
+                file=sys.stderr,
+            )
+
+        def fetch_cmd(term: str) -> list[str]:
+            cmd = [
+                py,
+                fetch,
+                "--term",
+                term,
+                "--delay",
+                str(args.fetch_delay),
+                "--timeout",
+                str(args.timeout),
+                "--referer",
+                args.referer,
+            ]
+            if args.only:
+                cmd.extend(["--only", args.only])
+            if args.cookie:
+                cmd.extend(["--cookie", args.cookie])
+            if args.dry_run_fetch:
+                cmd.append("--dry-run")
+            return cmd
+
+        run_step(fetch_cmd(args.fw_term), cwd=root)
+        if not args.skip_summer_fetch:
+            run_step(fetch_cmd(args.summer_term), cwd=root)
+
+    run_step(
+        [py, scrape, "--fall-winter-term", args.fw_term],
+        cwd=scrape_cwd,
+    )
+
+    run_step(
+        [py, gen, args.fw_term, args.summer_term],
+        cwd=root,
+    )
+
+    print("\nDone: db/seed.sql regenerated.", flush=True)
+
+    if apply_db:
+        if not Path(seed_sh).is_file():
+            print(f"Missing {seed_sh}", file=sys.stderr)
+            return 1
+        run_step(["/bin/bash", seed_sh], cwd=root)
+        print("\nDone: database seeded via scripts/seed.sh.", flush=True)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
- POST /api/v1/admin/seed/pipeline
- Authorization: Bearer token
- {"cookie":"…"} = Cookie for that run
- The handler will run `scripts/run_seed_pipeline.py` and seed end-to-end
- If SEED_PIPELINE_APPLY_DB=true, it also runs scripts/seed.sh, which compares sha256(db/seed.sql) to _seed_checksum, skips if unchanged, else truncates seeded tables, loads SQL, updates checksum (same as manual deploy seed).

Relies on:
```
SEED_PIPELINE_TOKEN
DATABASE_URL
PORT
```