### PR TITLE
Adding edge case handoing

### DIFF
--- a/scraping/scrapers/scrape.py
+++ b/scraping/scrapers/scrape.py
@@ -161,4 +161,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/scripts/fetch_page_sources.py
+++ b/scripts/fetch_page_sources.py
@@ -6,6 +6,7 @@ scraping/page_source/catalog_resource_map.json.
 Usage:
   python scripts/fetch_page_sources.py --term fall-winter-2026-2027
   python scripts/fetch_page_sources.py --term summer-2026
+  python scripts/fetch_page_sources.py --term fall-winter-2026-2027,summer-2026
   python scraping/scrapers/scrape.py --fall-winter-term fall-winter-2026-2027
   python scripts/run_seed_pipeline.py
   python scripts/fetch_page_sources.py --term fall-winter-2025-2026 --only schulich,science
@@ -209,6 +210,96 @@ def _maybe_keep_prior_page_source(
     return True, ""
 
 
+def _parse_term_list(term_arg: str) -> list[str]:
+    """Split --term by comma; trim; drop empties."""
+    return [part.strip() for part in term_arg.split(",") if part.strip()]
+
+
+def _fetch_files_for_term(
+    *,
+    root: Path,
+    args: argparse.Namespace,
+    data: dict,
+    term_key: str,
+    fetch_count: list[int],
+) -> tuple[int, int]:
+    """Download all stems for one catalog term. Returns (errors, guard_skips)."""
+    terms = data.get("terms") or {}
+    term_cfg = terms[term_key]
+    base_url = data.get("base_url", "").rstrip("/") + "/"
+    year_prefix = term_cfg.get("year_prefix")
+    stems = term_cfg.get("stem_to_faculty_code") or {}
+    if not year_prefix or not stems:
+        print(f"Term {term_key!r} missing year_prefix or stem_to_faculty_code", file=sys.stderr)
+        return 1, 0
+
+    only = {s.strip() for s in args.only.split(",") if s.strip()}
+    dest_dir = args.out_dir / term_key
+    if not args.dry_run:
+        dest_dir.mkdir(parents=True, exist_ok=True)
+
+    errors = 0
+    guard_skips = 0
+    for stem, code in sorted(stems.items(), key=lambda x: x[0]):
+        if only and stem not in only:
+            continue
+        filename = f"{year_prefix}{code}.html"
+        url = base_url + filename
+        out_path = dest_dir / f"{stem}.html"
+
+        if args.dry_run:
+            print(f"{term_key}/{stem}: {url} -> {out_path.relative_to(root)}")
+            continue
+
+        if fetch_count[0] > 0 and args.delay > 0:
+            time.sleep(args.delay)
+        fetch_count[0] += 1
+
+        try:
+            body = fetch_url(
+                url,
+                timeout=args.timeout,
+                referer=(args.referer or ""),
+                cookie=(args.cookie or ""),
+            )
+        except urllib.error.HTTPError as e:
+            print(f"HTTP {e.code} {term_key}/{stem}: {url}", file=sys.stderr)
+            errors += 1
+            continue
+        except urllib.error.URLError as e:
+            print(f"URL error {term_key}/{stem}: {e.reason!r} ({url})", file=sys.stderr)
+            errors += 1
+            continue
+        except Exception as e:
+            print(f"Error {term_key}/{stem}: {e} ({url})", file=sys.stderr)
+            errors += 1
+            continue
+
+        if looks_like_passport_block(body):
+            print(
+                f"{term_key}/{stem}: got Passport York / SSO page instead of timetable "
+                f"(need --cookie from logged-in browser?). {url}",
+                file=sys.stderr,
+            )
+            errors += 1
+            continue
+
+        to_write = html_bytes_for_disk(body)
+        write_ok, guard_msg = _maybe_keep_prior_page_source(
+            stem=f"{term_key}/{stem}", out_path=out_path, incoming_disk_bytes=to_write
+        )
+        if not write_ok:
+            guard_skips += 1
+            print(guard_msg, file=sys.stderr)
+            print(f"Skipped write (prior kept) -> {out_path.relative_to(root)}")
+            continue
+
+        out_path.write_bytes(to_write)
+        print(f"Wrote {len(to_write)} bytes -> {out_path.relative_to(root)}")
+
+    return errors, guard_skips
+
+
 def fetch_url(
     url: str,
     *,
@@ -242,7 +333,9 @@ def main() -> int:
     p.add_argument(
         "--term",
         required=True,
-        help="Term folder key, e.g. fall-winter-2026-2027",
+        metavar="KEY[,KEY...]",
+        help="Term folder key(s) from catalog_resource_map.json, comma-separated to fetch several in one run "
+        "(e.g. fall-winter-2026-2027,summer-2026).",
     )
     p.add_argument("--map", type=Path, default=default_map, help="Path to catalog_resource_map.json")
     p.add_argument(
@@ -289,83 +382,35 @@ def main() -> int:
         return 1
 
     data = load_map(args.map)
-    base_url = data.get("base_url", "").rstrip("/") + "/"
     terms = data.get("terms") or {}
-    if args.term not in terms:
-        print(f"Unknown term {args.term!r}. Known: {', '.join(sorted(terms))}", file=sys.stderr)
+    term_list = _parse_term_list(args.term)
+    if not term_list:
+        print(
+            "No terms in --term (example: fall-winter-2026-2027 or fall-winter-2026-2027,summer-2026)",
+            file=sys.stderr,
+        )
         return 1
-
-    term_cfg = terms[args.term]
-    year_prefix = term_cfg.get("year_prefix")
-    stems = term_cfg.get("stem_to_faculty_code") or {}
-    if not year_prefix or not stems:
-        print(f"Term {args.term!r} missing year_prefix or stem_to_faculty_code", file=sys.stderr)
-        return 1
-
-    only = {s.strip() for s in args.only.split(",") if s.strip()}
-
-    dest_dir = args.out_dir / args.term
-    if not args.dry_run:
-        dest_dir.mkdir(parents=True, exist_ok=True)
+    for tk in term_list:
+        if tk not in terms:
+            print(
+                f"Unknown term {tk!r}. Known: {', '.join(sorted(terms))}",
+                file=sys.stderr,
+            )
+            return 1
 
     errors = 0
     guard_skips = 0
-    fetch_index = 0
-    for stem, code in sorted(stems.items(), key=lambda x: x[0]):
-        if only and stem not in only:
-            continue
-        filename = f"{year_prefix}{code}.html"
-        url = base_url + filename
-        out_path = dest_dir / f"{stem}.html"
-
-        if args.dry_run:
-            print(f"{stem}: {url} -> {out_path.relative_to(root)}")
-            continue
-
-        if fetch_index > 0 and args.delay > 0:
-            time.sleep(args.delay)
-        fetch_index += 1
-
-        try:
-            body = fetch_url(
-                url,
-                timeout=args.timeout,
-                referer=(args.referer or ""),
-                cookie=(args.cookie or ""),
-            )
-        except urllib.error.HTTPError as e:
-            print(f"HTTP {e.code} {stem}: {url}", file=sys.stderr)
-            errors += 1
-            continue
-        except urllib.error.URLError as e:
-            print(f"URL error {stem}: {e.reason!r} ({url})", file=sys.stderr)
-            errors += 1
-            continue
-        except Exception as e:
-            print(f"Error {stem}: {e} ({url})", file=sys.stderr)
-            errors += 1
-            continue
-
-        if looks_like_passport_block(body):
-            print(
-                f"{stem}: got Passport York / SSO page instead of timetable (need --cookie from logged-in browser?). {url}",
-                file=sys.stderr,
-            )
-            errors += 1
-            continue
-
-        to_write = html_bytes_for_disk(body)
-        write_ok, guard_msg = _maybe_keep_prior_page_source(
-            stem=stem, out_path=out_path, incoming_disk_bytes=to_write
+    fetch_count = [0]
+    for tk in term_list:
+        e, g = _fetch_files_for_term(
+            root=root,
+            args=args,
+            data=data,
+            term_key=tk,
+            fetch_count=fetch_count,
         )
-        if not write_ok:
-            guard_skips += 1
-            print(guard_msg, file=sys.stderr)
-            print(f"Skipped write (prior kept) -> {out_path.relative_to(root)}")
-            continue
-
-        out_path.write_bytes(to_write)
-        print(f"Wrote {len(to_write)} bytes -> {out_path.relative_to(root)}")
+        errors += e
+        guard_skips += g
 
     if guard_skips:
         print(

--- a/scripts/fetch_page_sources.py
+++ b/scripts/fetch_page_sources.py
@@ -14,6 +14,11 @@ Usage:
   # If you get Passport York HTML instead of timetables, pass session cookies from a logged-in browser:
   python scripts/fetch_page_sources.py --term fall-winter-2026-2027 --cookie 'name=value; other=...'
 
+When a new download looks empty or much smaller than the existing file on disk (e.g. timetable
+not released), the prior HTML is kept and the write is skipped — see PAGE_SOURCE_* env vars in
+run_seed_pipeline.py. Use --fail-on-guard-skip or PAGE_SOURCE_FAIL_ON_GUARD_SKIP=1 so the process
+exits 3 and a human can review before forcing PAGE_SOURCE_ALLOW_DEGRADED_OVERWRITE=1.
+
 Requires network access to apps1.sis.yorku.ca (no extra pip packages).
 """
 
@@ -21,6 +26,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 import time
 import urllib.error
@@ -51,6 +57,156 @@ def html_bytes_for_disk(body: bytes) -> bytes:
     if body.startswith((b"\xff\xfe", b"\xfe\xff")):
         return body.decode("utf-16").encode("utf-8")
     return body
+
+
+def _html_utf8_text(disk_bytes: bytes) -> str:
+    return disk_bytes.decode("utf-8", errors="replace")
+
+
+def _html_tr_count(html: str) -> int:
+    """Cheap proxy for timetable size (no BeautifulSoup)."""
+    return html.lower().count("<tr")
+
+
+def _looks_like_timetable_placeholder(html: str) -> bool:
+    """SIS sometimes serves a stub page when timetables are not released."""
+    t = html.lower()
+    needles = (
+        "not been released",
+        "not yet been released",
+        "not available at this time",
+        "timetable has not",
+        "please check back",
+        "no courses available",
+    )
+    return any(n in t for n in needles)
+
+
+def _cancellation_mention_count(html: str) -> int:
+    t = html.lower()
+    return (
+        t.count("cancelled")
+        + t.count("canceled")
+        + t.count("cancellation")
+        + t.count("cancellations")
+    )
+
+
+def _bypass_preserve_for_cancellations(old_tr: int, new_tr: int, new_html: str) -> bool:
+    """
+    Large row-count drops are suspicious, but real timetables often mark removals as cancelled.
+    If the new HTML has enough cancellation language on a non-tiny page, accept the update.
+    """
+    if new_tr < 12:
+        return False
+    mentions = _cancellation_mention_count(new_html)
+    if mentions < 8:
+        return False
+    # Scale with prior size: big timetables may list many cancelled sections.
+    if mentions >= max(16, old_tr // 35):
+        return True
+    # Moderate drop but cancellation wording throughout.
+    if new_tr >= old_tr * 0.30 and mentions >= 14:
+        return True
+    return False
+
+
+def _default_regression_ratio() -> float:
+    # Default 0.55: new file must keep ≥55% of prior <tr> proxy (bias toward not losing data).
+    raw = os.environ.get("PAGE_SOURCE_REGRESSION_RATIO", "0.55").strip()
+    try:
+        r = float(raw)
+    except ValueError:
+        return 0.55
+    if not 0 < r <= 1:
+        return 0.55
+    return r
+
+
+def _default_regression_min_prior_tr() -> int:
+    raw = os.environ.get("PAGE_SOURCE_REGRESSION_MIN_PRIOR", "70").strip()
+    try:
+        n = int(raw)
+    except ValueError:
+        return 70
+    return max(0, n)
+
+
+def _truthy_env(name: str) -> bool:
+    v = os.environ.get(name, "").strip().lower()
+    return v in ("1", "true", "yes", "on")
+
+
+def _allow_degraded_page_source_overwrite() -> bool:
+    return _truthy_env("PAGE_SOURCE_ALLOW_DEGRADED_OVERWRITE")
+
+
+def _should_preserve_prior_page_source(old_tr: int, new_tr: int, new_html: str) -> bool:
+    """
+    Keep existing on-disk HTML when the new download looks empty or far smaller (<tr> proxy).
+
+    - new has no rows while prior had rows
+    - placeholder/stub text and far fewer rows
+    - default: new < PAGE_SOURCE_REGRESSION_RATIO (default 0.55) × old, when old has at least
+      PAGE_SOURCE_REGRESSION_MIN_PRIOR (default 70) <tr> — catches e.g. full timetable → one course
+
+    Override: PAGE_SOURCE_ALLOW_DEGRADED_OVERWRITE=1, or cancellation-heavy new HTML
+    (_bypass_preserve_for_cancellations).
+    """
+    if old_tr <= 0:
+        return False
+    if new_tr == 0:
+        return True
+
+    if _bypass_preserve_for_cancellations(old_tr, new_tr, new_html):
+        return False
+
+    if old_tr >= 30 and _looks_like_timetable_placeholder(new_html) and new_tr < max(15, int(old_tr * 0.25)):
+        return True
+
+    min_ratio = _default_regression_ratio()
+    min_prior = _default_regression_min_prior_tr()
+    if old_tr < min_prior:
+        return False
+    if new_tr < old_tr * min_ratio:
+        return True
+    return False
+
+
+def _maybe_keep_prior_page_source(
+    *,
+    stem: str,
+    out_path: Path,
+    incoming_disk_bytes: bytes,
+) -> tuple[bool, str]:
+    """
+    Returns (wrote_incoming, message for log). If False, caller should skip write
+    (disk file unchanged).
+    """
+    if _allow_degraded_page_source_overwrite():
+        return True, ""
+
+    if not out_path.is_file():
+        return True, ""
+
+    try:
+        prior_bytes = out_path.read_bytes()
+    except OSError:
+        return True, ""
+
+    new_html = _html_utf8_text(incoming_disk_bytes)
+    prior_html = _html_utf8_text(prior_bytes)
+    old_tr = _html_tr_count(prior_html)
+    new_tr = _html_tr_count(new_html)
+
+    if _should_preserve_prior_page_source(old_tr, new_tr, new_html):
+        reason = (
+            f"[page_source guard] {stem}: keeping prior file "
+            f"(prior <tr>≈{old_tr}, new <tr>≈{new_tr}); not overwriting with degraded fetch"
+        )
+        return False, reason
+
+    return True, ""
 
 
 def fetch_url(
@@ -120,6 +276,12 @@ def main() -> int:
         metavar="STRING",
         help="Raw Cookie header value from a logged-in browser session (DevTools → Network → request headers).",
     )
+    p.add_argument(
+        "--fail-on-guard-skip",
+        action="store_true",
+        help="Exit with code 3 if any file was not written because the page_source guard kept prior HTML "
+        "(same as PAGE_SOURCE_FAIL_ON_GUARD_SKIP=1). Use in automation so someone must review or force overwrite.",
+    )
     args = p.parse_args()
 
     if not args.map.is_file():
@@ -147,6 +309,7 @@ def main() -> int:
         dest_dir.mkdir(parents=True, exist_ok=True)
 
     errors = 0
+    guard_skips = 0
     fetch_index = 0
     for stem, code in sorted(stems.items(), key=lambda x: x[0]):
         if only and stem not in only:
@@ -192,10 +355,38 @@ def main() -> int:
             continue
 
         to_write = html_bytes_for_disk(body)
+        write_ok, guard_msg = _maybe_keep_prior_page_source(
+            stem=stem, out_path=out_path, incoming_disk_bytes=to_write
+        )
+        if not write_ok:
+            guard_skips += 1
+            print(guard_msg, file=sys.stderr)
+            print(f"Skipped write (prior kept) -> {out_path.relative_to(root)}")
+            continue
+
         out_path.write_bytes(to_write)
         print(f"Wrote {len(to_write)} bytes -> {out_path.relative_to(root)}")
 
-    return 1 if errors else 0
+    if guard_skips:
+        print(
+            f"\npage_source guard: kept prior HTML for {guard_skips} file(s). "
+            "To accept the fetched version anyway, re-run with PAGE_SOURCE_ALLOW_DEGRADED_OVERWRITE=1 "
+            "or review the new downloads in a browser.",
+            file=sys.stderr,
+        )
+
+    if errors:
+        return 1
+
+    fail_guard = args.fail_on_guard_skip or _truthy_env("PAGE_SOURCE_FAIL_ON_GUARD_SKIP")
+    if fail_guard and guard_skips:
+        print(
+            "Exiting with code 3: fail-on-guard-skip enabled and at least one prior file was preserved.",
+            file=sys.stderr,
+        )
+        return 3
+
+    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/generate_seed.py
+++ b/scripts/generate_seed.py
@@ -435,7 +435,14 @@ if __name__ == '__main__':
         default=["fall-winter-2026-2027", "summer-2026"],
         metavar="DIR",
         help="Subdirs of scraping/data, or absolute paths to folders of *.json "
-        "(default: fall-winter-2026-2027 summer-2026). Pass only one dir to exclude summer.",
+        "(default: fall-winter-2026-2027 summer-2026). The full db/seed.sql is rebuilt from "
+        "only these folders — omitting a term drops that term's courses from the SQL entirely.",
+    )
+    parser.add_argument(
+        "--allow-partial-seed",
+        action="store_true",
+        help="Allow a single term dir (dangerous: seed.sql will not include other terms; "
+        "applying it effectively removes those courses from the DB).",
     )
     parser.add_argument(
         "-o",
@@ -450,7 +457,17 @@ if __name__ == '__main__':
     )
     args = parser.parse_args()
 
-    json_files = _collect_json_paths(repo_root, data_root, list(args.term_dirs))
+    term_list = list(args.term_dirs)
+    if len(term_list) == 1 and not args.allow_partial_seed:
+        print(
+            "Refusing to generate seed from a single term dir (seed.sql would omit all other terms).\n"
+            "Pass every term you need (e.g. fall-winter-2026-2027 summer-2026) or add "
+            "--allow-partial-seed if you really want a partial export.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    json_files = _collect_json_paths(repo_root, data_root, term_list)
 
     if not json_files:
         print("No JSON files found (check term_dirs paths).", file=sys.stderr)

--- a/scripts/run_seed_pipeline.py
+++ b/scripts/run_seed_pipeline.py
@@ -109,12 +109,12 @@ def main() -> int:
                 file=sys.stderr,
             )
 
-        def fetch_cmd(term: str) -> list[str]:
+        def fetch_cmd(term_csv: str) -> list[str]:
             cmd = [
                 py,
                 fetch,
                 "--term",
-                term,
+                term_csv,
                 "--delay",
                 str(args.fetch_delay),
                 "--timeout",
@@ -130,9 +130,10 @@ def main() -> int:
                 cmd.append("--dry-run")
             return cmd
 
-        run_step(fetch_cmd(args.fw_term), cwd=root)
+        fetch_terms = args.fw_term
         if not args.skip_summer_fetch:
-            run_step(fetch_cmd(args.summer_term), cwd=root)
+            fetch_terms = f"{args.fw_term},{args.summer_term}"
+        run_step(fetch_cmd(fetch_terms), cwd=root)
 
     run_step(
         [py, scrape, "--fall-winter-term", args.fw_term],

--- a/scripts/run_seed_pipeline.py
+++ b/scripts/run_seed_pipeline.py
@@ -6,6 +6,10 @@ Environment:
   DATABASE_URL          Used by seed.sh when you pass --apply-db (or API does, if DATABASE_URL was set at startup).
   YORK_SIS_COOKIE       Optional fallback for SIS fetch; API usually sends cookie in POST JSON instead.
   SEED_PIPELINE_APPLY_DB  CLI: "1"/"true" or --apply-db to run seed.sh after generating db/seed.sql.
+  PAGE_SOURCE_ALLOW_DEGRADED_OVERWRITE  If "1"/"true", allow fetch to overwrite with smaller/empty HTML (default: keep prior page_source).
+  PAGE_SOURCE_REGRESSION_RATIO  Min fraction of prior <tr> the new file must reach (default 0.55); below that, prior is kept unless the new HTML looks cancellation-heavy.
+  PAGE_SOURCE_REGRESSION_MIN_PRIOR  Only apply ratio when prior has at least this many <tr> (default 70).
+  PAGE_SOURCE_FAIL_ON_GUARD_SKIP  If "1"/"true", fetch exits 3 when any file was skipped by the guard (for automation / human review).
 
 CLI (from repository root):
   python3 scripts/run_seed_pipeline.py

--- a/scripts/test_generate_seed.py
+++ b/scripts/test_generate_seed.py
@@ -6,8 +6,10 @@ import unittest
 import json
 import tempfile
 import os
+import subprocess
+import sys
 import uuid
-import runpy
+from pathlib import Path
 from unittest.mock import patch, mock_open
 from generate_seed import (
     escape_sql_string,
@@ -1127,11 +1129,35 @@ class TestGenerateSeedMain(unittest.TestCase):
     """Test __main__ block behavior"""
 
     def test_main_exits_when_no_json_files(self):
-        with patch('glob.glob', return_value=[]), \
-             patch('builtins.print'):
-            with self.assertRaises(SystemExit) as ctx:
-                runpy.run_module('generate_seed', run_name='__main__')
-            self.assertEqual(ctx.exception.code, 1)
+        repo = Path(__file__).resolve().parents[1]
+        script = repo / "scripts" / "generate_seed.py"
+        with tempfile.TemporaryDirectory() as empty_a, tempfile.TemporaryDirectory() as empty_b:
+            r = subprocess.run(
+                [
+                    sys.executable,
+                    str(script),
+                    empty_a,
+                    empty_b,
+                    "-o",
+                    str(Path(empty_a) / "out.sql"),
+                ],
+                cwd=str(repo),
+                capture_output=True,
+                text=True,
+            )
+        self.assertEqual(r.returncode, 1)
+
+    def test_main_rejects_single_term_without_flag(self):
+        repo = Path(__file__).resolve().parents[1]
+        script = repo / "scripts" / "generate_seed.py"
+        with tempfile.TemporaryDirectory() as td:
+            r = subprocess.run(
+                [sys.executable, str(script), td],
+                cwd=str(repo),
+                capture_output=True,
+                text=True,
+            )
+        self.assertEqual(r.returncode, 2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Page-source guard in fetch_page_sources.py: Before overwriting scraping/page_source/.../*.html, compare the new download to the file on disk using a cheap <tr>-count proxy, “not released”-style placeholder text, and optional cancellation wording so real mass cancellations can still land.
- Default safety: PAGE_SOURCE_REGRESSION_RATIO defaults to 0.55 with PAGE_SOURCE_REGRESSION_MIN_PRIOR 70 <tr> so large drops (e.g. full timetable → stub) keep the previous HTML instead of wiping it.
- Overrides: PAGE_SOURCE_ALLOW_DEGRADED_OVERWRITE=1 forces accepting smaller/newer HTML after you’ve checked it; ratio/min prior stay tunable via env.
- Human / automation hook: --fail-on-guard-skip or PAGE_SOURCE_FAIL_ON_GUARD_SKIP=1 makes fetch exit 3 when any write was skipped by the guard (exit 1 stays for HTTP/SSO errors), so CI or deploys can stop for review.

ALL CASES:

1. Download both terms (normal guard)

```
export COOKIE='paste_full_cookie_header_here'
python3 scripts/fetch_page_sources.py --term fall-winter-2026-2027,summer-2026 --cookie "$COOKIE"
```

2. Same, but allow smaller/new HTML after you’ve checked it

```
PAGE_SOURCE_ALLOW_DEGRADED_OVERWRITE=1 
python3 scripts/fetch_page_sources.py --term fall-winter-2026-2027,summer-2026 --cookie "$COOKIE"
```

3. Full pipeline: fetch both → scrape → db/seed.sql (no DB apply)

```
python3 scripts/run_seed_pipeline.py --cookie "$COOKIE"
```

5. Full pipeline + load DB (needs DATABASE_URL / your seed.sh setup)

```
python3 scripts/run_seed_pipeline.py --cookie "$COOKIE" --apply-db
```

7. Already have HTML; only scrape + seed

```
python3 scripts/run_seed_pipeline.py --skip-fetch
```